### PR TITLE
Calculate CRC using Intel DSA

### DIFF
--- a/src/overlaybd/fs/zfile/CMakeLists.txt
+++ b/src/overlaybd/fs/zfile/CMakeLists.txt
@@ -1,11 +1,30 @@
-file(GLOB SOURCE_ZFILE "*.cpp") 
+file(GLOB SOURCE_ZFILE "*.cpp")
 file(GLOB SOURCE_LZ4 "lz4/lz4.c")
-file(GLOB SOURCE_CRC32 "crc32/*.cpp") 
+file(GLOB SOURCE_CRC32 "crc32/*.cpp")
 
 add_library(zfile_lib STATIC ${SOURCE_ZFILE} ${SOURCE_LZ4} ${SOURCE_CRC32})
 target_compile_options(zfile_lib PUBLIC -msse4.2 -mcrc32)
-target_link_libraries(zfile_lib)
 
-if(BUILD_TESTING)
-  add_subdirectory(test)
-endif()
+set(CHECK_DSA_CMD "if lspci -nn | grep 8086:0b25 > /dev/null \; then echo -n yes\; else echo -n no\; fi")
+execute_process(COMMAND bash -c ${CHECK_DSA_CMD} OUTPUT_VARIABLE HAS_DSA)
+
+if (${HAS_DSA} STREQUAL "yes")
+    add_definitions(-DENABLE_DSA=yes)
+    target_link_libraries(zfile_lib ${LIBRARY_OUTPUT_PATH}/libaccel-config.so -luuid)
+    add_custom_command(TARGET zfile_lib
+            PRE_BUILD
+            COMMENT "Found Intel DSA device, going to build libaccel-config"
+            COMMAND rm -rf idxd-config/
+            COMMAND git clone https://github.com/intel/idxd-config && cd idxd-config && git checkout stable
+            COMMAND cd idxd-config && ./autogen.sh && ./configure --disable-docs --disable-logging
+            COMMAND cd idxd-config && make -j
+            COMMAND cd idxd-config && cp -P ./accfg/lib/.libs/libaccel-config.so ${LIBRARY_OUTPUT_PATH} &&
+                cp -P ./accfg/lib/.libs/libaccel-config.so.1 ${LIBRARY_OUTPUT_PATH} &&
+                cp ./accfg/lib/.libs/libaccel-config.so.1.0.0 ${LIBRARY_OUTPUT_PATH}
+            VERBATIM
+            )
+endif ()
+
+if (BUILD_TESTING)
+    add_subdirectory(test)
+endif ()

--- a/src/overlaybd/fs/zfile/crc32/README
+++ b/src/overlaybd/fs/zfile/crc32/README
@@ -1,0 +1,55 @@
+1. Introduction
+
+Intel® DSA is a high-performance data copy and transformation accelerator that will be
+integrated into future Intel® processors, targeted for optimizing streaming data movement
+and transformation operations common with applications for high-performance storage,
+networking, persistent memory, and various data processing applications.
+
+Intel® DSA replaces the Intel® QuickData Technology, which is a part of Intel® I/O 
+Acceleration Technology.
+
+The goal is to provide higher overall system performance for data mover and transformation
+operations while freeing up CPU cycles for higher-level functions. Intel® DSA enables
+high-performance data mover capability to/from volatile memory, persistent memory,
+memory-mapped I/O, and through a Non-Transparent Bridge (NTB) device to/from remote volatile
+and persistent memory on another node in a cluster. Enumeration and configuration are done
+with a PCI Express* compatible programming interface to the Operating System (OS) and can be
+controlled through a device driver.
+
+Besides the basic data mover operations, Intel® DSA supports a set of transformation
+operations on memory. For example:
+
+Generate and test CRC checksum, or Data Integrity Field (DIF) to support storage and
+networking applications.
+Memory Compare and delta generate/merge to support VM migration, VM Fast check-pointing, and
+software-managed memory deduplication usages.
+
+We did a performance comparison test, and the QPS calculated by CRC were 960124 and 7977434
+respectively in the case of 4K size without and with DSA. About a nine-times improvement
+using DSA in performance.
+
+2. Check DSA hardware
+  $ lspci -nn | grep 8086:0b25
+ 
+ If get any information, which mean the system have DSA hardware
+
+3. build libaccel-config
+3.1 install dependency package
+  For ubuntu:
+    $ sudo apt install -y uuid-dev libjson-c-dev libkmod-dev libsystemd-dev autoconf automake libtool
+  For centos
+    $ yum install -y libuuid-devel json-c-devel kmod-devel systemd-devel autoconf automake libtool
+   
+3.2 build share library
+    $ git clone https://github.com/intel/idxd-config && cd idxd-config && git checkout stable
+    $ cd idxd-config
+    $ ./autogen.sh && ./configure --disable-docs --disable-logging
+    $ make -j
+    $ cp -P ./accfg/lib/.libs/libaccel-config.so ${LIBRARY_OUTPUT_PATH}
+    $ cp -P ./accfg/lib/.libs/libaccel-config.so.1 ${LIBRARY_OUTPUT_PATH}
+    $ cp ./accfg/lib/.libs/libaccel-config.so.1.0.0 ${LIBRARY_OUTPUT_PATH}
+
+4. Unit test for DSA Calculate CRC
+  $ cmake -D BUILD_TESTING=1 ..
+  $ make -j
+  $./output/zfile_test

--- a/src/overlaybd/fs/zfile/crc32/crc32c.cpp
+++ b/src/overlaybd/fs/zfile/crc32/crc32c.cpp
@@ -20,7 +20,11 @@
 #include <algorithm>
 #include <iostream>
 
+#include "../../../alog.h"
 #include "crc32c.h"
+#ifdef ENABLE_DSA
+#include "dsa.h"
+#endif
 
 namespace FileSystem {
 
@@ -709,6 +713,8 @@ static uint32_t multitable_crc32c(uint32_t crc32c, const unsigned char *buffer,
   return (crc32c_sb8_64_bit(crc32c, buffer, length, to_even_word));
 }
 
+
+
 static uint32_t crc32c_sw(const uint8_t *buffer, size_t nbytes, uint32_t crc) {
   if (nbytes < 4) {
     return (singletable_crc32c(crc, buffer, nbytes));
@@ -717,13 +723,66 @@ static uint32_t crc32c_sw(const uint8_t *buffer, size_t nbytes, uint32_t crc) {
   }
 }
 
+#ifdef ENABLE_DSA
+static dsa_context* dsa;
+
+static uint32_t crc32c_hw_dsa(const uint8_t* data, size_t nbytes, uint32_t crc) {
+    int rc = 0;
+    int flags = 0x1;
+    int opcode = DSA_OPCODE_CRCGEN;
+    task* tsk;
+    tsk = dsa->single_task;
+    rc = init_task(tsk, flags, opcode, data, nbytes, crc);
+    if (rc != DSA_STATUS_OK) {
+        LOG_ERROR_RETURN(0, rc, "dsa: init task failed");
+    }
+
+    rc = dsa_crcgen(dsa);
+    if (rc != DSA_STATUS_OK) {
+        errno = ENXIO;
+        LOG_ERRNO_RETURN(0, rc, "dsa: crcgen failed stat");
+    }
+
+    rc = task_result_verify(tsk, 0);
+    if (rc != DSA_STATUS_OK) {
+        LOG_ERRNO_RETURN(0, rc, "dsa: verify task failed");
+    }
+
+    clean_task(tsk);
+    return (tsk->comp->crc_val^0xFFFFFFFF);
+}
+
+static int init_dsa() {
+    dsa = dsa_init();
+    if (dsa == nullptr) {
+        LOG_ERROR_RETURN(0, -1, "failed to init dsa");
+    }
+    int rc = dsa_alloc(dsa, SHARED);
+    if (rc < 0) {
+        LOG_ERROR_RETURN(0, -1, "alloc dsa failed, rc=`", rc)
+    }
+    rc = alloc_task(dsa);
+    if (rc != DSA_STATUS_OK) {
+        LOG_ERROR_RETURN(0, -1, "alloc dsa task failed, rc=`", rc)
+    }
+
+    crc32c_func = crc32c_hw_dsa;
+    return 0;
+}
+#endif
+
 static void crc_init() {
-  __builtin_cpu_init();
-  if (__builtin_cpu_supports("sse4.2")) {
-    crc32c_func = crc32c_hw;
-  } else {
-    crc32c_func = crc32c_sw;
-  }
+#ifdef ENABLE_DSA
+    if (init_dsa() == 0) {
+        return;
+    }
+#endif
+    __builtin_cpu_init();
+    if (__builtin_cpu_supports("sse4.2")) {
+        crc32c_func = crc32c_hw;
+    } else {
+        crc32c_func = crc32c_sw;
+    }
 }
 
 static void crc_deinit() {

--- a/src/overlaybd/fs/zfile/crc32/crc32c.cpp
+++ b/src/overlaybd/fs/zfile/crc32/crc32c.cpp
@@ -29,6 +29,7 @@ namespace crc32 {
 static uint32_t (*crc32c_func)(const uint8_t *, size_t, uint32_t) = nullptr;
 
 static void crc_init() __attribute__((constructor));
+static void crc_deinit() __attribute__((destructor));
 
 static uint32_t crc32c_hw(const uint8_t *data, size_t nbytes, uint32_t crc) {
   uint32_t sum = crc;
@@ -724,6 +725,13 @@ static void crc_init() {
     crc32c_func = crc32c_sw;
   }
 }
+
+static void crc_deinit() {
+#ifdef ENABLE_DSA
+   dsa_free(dsa);
+#endif
+}
+
 
 uint32_t crc32c_extend(const void *data, size_t nbytes, uint32_t crc) {
   return crc32c_func(reinterpret_cast<const uint8_t *>(data), nbytes, crc);

--- a/src/overlaybd/fs/zfile/crc32/dsa.cpp
+++ b/src/overlaybd/fs/zfile/crc32/dsa.cpp
@@ -1,0 +1,668 @@
+// SPDX-License-Identifier: GPL-2.0
+/* Copyright(c) 2019 Intel Corporation. All rights reserved. */
+#include <stdio.h>
+#include <stdint.h>
+#include <string.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <libgen.h>
+#include <errno.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <fcntl.h>
+#include <sys/mman.h>
+#include <linux/vfio.h>
+#include "dsa.h"
+
+#define DSA_COMPL_RING_SIZE 64
+
+unsigned int ms_timeout = 5000;
+int debug_logging;
+static int umwait_support;
+
+static inline void cpuid(unsigned int *eax, unsigned int *ebx,
+		unsigned int *ecx, unsigned int *edx)
+{
+	/* ecx is often an input as well as an output. */
+	asm volatile("cpuid"
+		: "=a" (*eax),
+		"=b" (*ebx),
+		"=c" (*ecx),
+		"=d" (*edx)
+		: "0" (*eax), "2" (*ecx)
+		: "memory");
+}
+
+struct dsa_context *dsa_init(void)
+{
+	struct dsa_context *dctx;
+	unsigned int unused[2];
+	unsigned int leaf, waitpkg;
+	int rc;
+	struct accfg_ctx *ctx;
+
+	/* detect umwait support */
+	leaf = 7;
+	waitpkg = 0;
+	cpuid(&leaf, unused, &waitpkg, unused+1);
+	if (waitpkg & 0x20) {
+		dbg("umwait supported\n");
+		umwait_support = 1;
+	}
+
+	dctx = (struct dsa_context *)malloc(sizeof(struct dsa_context));
+	if (!dctx)
+		return NULL;
+	memset(dctx, 0, sizeof(struct dsa_context));
+
+	rc = accfg_new(&ctx);
+	if (rc < 0) {
+		free(dctx);
+		return NULL;
+	}
+
+	dctx->ctx = ctx;
+	return dctx;
+}
+
+static int dsa_setup_wq(struct dsa_context *ctx, struct accfg_wq *wq)
+{
+	char path[PATH_MAX];
+	int rc;
+
+	rc = accfg_wq_get_user_dev_path(wq, path, PATH_MAX);
+	if (rc) {
+		fprintf(stderr, "Error getting uacce device path\n");
+		return rc;
+	}
+
+	ctx->fd = open(path, O_RDWR);
+	if (ctx->fd < 0) {
+		perror("open");
+		return -errno;
+	}
+
+	ctx->wq_reg = mmap(NULL, 0x1000, PROT_WRITE,
+			MAP_SHARED | MAP_POPULATE, ctx->fd, 0);
+	if (ctx->wq_reg == MAP_FAILED) {
+		perror("mmap");
+		return -errno;
+	}
+
+	return 0;
+}
+
+static struct accfg_wq *dsa_get_wq(struct dsa_context *ctx,
+		int dev_id, int shared)
+{
+	struct accfg_device *device;
+	struct accfg_wq *wq;
+	int rc;
+
+	accfg_device_foreach(ctx->ctx, device) {
+		enum accfg_device_state dstate;
+
+		/* Make sure that the device is enabled */
+		dstate = accfg_device_get_state(device);
+		if (dstate != ACCFG_DEVICE_ENABLED)
+			continue;
+
+		/* Match the device to the id requested */
+		if (accfg_device_get_id(device) != dev_id &&
+				dev_id != -1)
+			continue;
+
+		accfg_wq_foreach(device, wq) {
+			enum accfg_wq_state wstate;
+			enum accfg_wq_mode mode;
+			enum accfg_wq_type type;
+
+			/* Get a workqueue that's enabled */
+			wstate = accfg_wq_get_state(wq);
+			if (wstate != ACCFG_WQ_ENABLED)
+				continue;
+
+			/* The wq type should be user */
+			type = accfg_wq_get_type(wq);
+			if (type != ACCFG_WQT_USER)
+				continue;
+
+			/* Make sure the mode is correct */
+			mode = accfg_wq_get_mode(wq);
+			if ((mode == ACCFG_WQ_SHARED && !shared)
+				|| (mode == ACCFG_WQ_DEDICATED && shared))
+				continue;
+
+			rc = dsa_setup_wq(ctx, wq);
+			if (rc < 0)
+				return NULL;
+
+			return wq;
+		}
+	}
+
+	return NULL;
+}
+
+static uint32_t bsr(uint32_t val)
+{
+	uint32_t msb;
+
+	msb = (val == 0) ? 0 : 32 - __builtin_clz(val);
+	return msb - 1;
+}
+
+int dsa_alloc(struct dsa_context *ctx, int shared)
+{
+	struct accfg_device *dev;
+
+	/* Is wq already allocated? */
+	if (ctx->wq_reg)
+		return 0;
+
+	ctx->wq = dsa_get_wq(ctx, -1, shared);
+	if (!ctx->wq) {
+		err("No usable wq found\n");
+		return -ENODEV;
+	}
+	dev = accfg_wq_get_device(ctx->wq);
+
+	ctx->dedicated = !shared;
+	ctx->wq_size = accfg_wq_get_size(ctx->wq);
+	ctx->wq_idx = accfg_wq_get_id(ctx->wq);
+	ctx->bof = accfg_wq_get_block_on_fault(ctx->wq);
+	ctx->wq_max_batch_size = accfg_wq_get_max_batch_size(ctx->wq);
+	ctx->wq_max_xfer_size = accfg_wq_get_max_transfer_size(ctx->wq);
+	ctx->ats_disable = accfg_wq_get_ats_disable(ctx->wq);
+
+	ctx->max_batch_size = accfg_device_get_max_batch_size(dev);
+	ctx->max_xfer_size = accfg_device_get_max_transfer_size(dev);
+	ctx->max_xfer_bits = bsr(ctx->max_xfer_size);
+
+	info("alloc wq %d shared %d size %d addr %p batch sz %#x xfer sz %#x\n",
+			ctx->wq_idx, shared, ctx->wq_size, ctx->wq_reg,
+			ctx->max_batch_size, ctx->max_xfer_size);
+
+	return 0;
+}
+
+int alloc_task(struct dsa_context *ctx)
+{
+	ctx->single_task = __alloc_task();
+	if (!ctx->single_task)
+		return -ENOMEM;
+
+	dbg("single task allocated, desc %#lx comp %#lx\n",
+			ctx->single_task->desc, ctx->single_task->comp);
+
+	return DSA_STATUS_OK;
+}
+
+struct task *__alloc_task(void)
+{
+	struct task *tsk;
+
+	tsk = (struct task *)malloc(sizeof(struct task));
+	if (!tsk)
+		return NULL;
+	memset(tsk, 0, sizeof(struct task));
+
+	tsk->desc = (struct dsa_hw_desc *)malloc(sizeof(struct dsa_hw_desc));
+	if (!tsk->desc) {
+		free_task(tsk);
+		return NULL;
+	}
+	memset(tsk->desc, 0, sizeof(struct dsa_hw_desc));
+
+	/* completion record need to be 32bits aligned */
+	tsk->comp = (struct dsa_completion_record *)aligned_alloc(32, sizeof(struct dsa_completion_record));
+	if (!tsk->comp) {
+		free_task(tsk);
+		return NULL;
+	}
+	memset(tsk->comp, 0, sizeof(struct dsa_completion_record));
+
+	return tsk;
+}
+
+/* this function is re-used by batch task */
+int init_task(struct task *tsk, int tflags, int opcode,
+		const uint8_t *data, unsigned long xfer_size, uint32_t crc_seed)
+{
+	dbg("initilizing single task %#lx\n", tsk);
+
+	tsk->pattern = 0x0123456789abcdef;
+	tsk->opcode = opcode;
+	tsk->test_flags = tflags;
+	tsk->xfer_size = xfer_size;
+
+	/* allocate memory: src1*/
+	switch (opcode) {
+	case DSA_OPCODE_CRCGEN:
+	case DSA_OPCODE_COPY_CRC:
+		tsk->src1 = (void *)data;
+		if (!tsk->src1)
+			return -ENOMEM;
+	}
+
+	/* allocate memory: dst1*/
+	switch (opcode) {
+	case DSA_OPCODE_COPY_CRC:
+		/* DUALCAST: dst1/dst2 lower 12 bits must be same */
+		tsk->dst1 = aligned_alloc(1<<12, xfer_size);
+		if (!tsk->dst1)
+			return -ENOMEM;
+		if (tflags & TEST_FLAGS_PREF)
+			memset(tsk->dst1, 0, xfer_size);
+	}
+
+	/* allocate memory: seed addr */
+	switch (opcode) {
+	case DSA_OPCODE_CRCGEN:
+		tsk->crc_seed = ~crc_seed;
+		break;
+
+	case DSA_OPCODE_COPY_CRC:
+		tsk->seed_addr = malloc(xfer_size);
+		if (!tsk->seed_addr)
+			return -ENOMEM;
+		memset_pattern(tsk->seed_addr, tsk->pattern, xfer_size);
+		tsk->crc_seed = crc_seed;
+	}
+
+	dbg("Mem allocated: s1 %#lx s2 %#lx d1 %#lx d2 %#lx sd %#lx\n",
+			tsk->src1, tsk->src2, tsk->dst1, tsk->dst2, tsk->seed_addr);
+
+	return DSA_STATUS_OK;
+}
+
+int dsa_enqcmd(struct dsa_context *ctx, struct dsa_hw_desc *hw)
+{
+	int retry_count = 0;
+	int ret = 0;
+
+	while (retry_count < 3) {
+		if (!enqcmd(ctx->wq_reg, hw))
+			break;
+
+		info("retry\n");
+		retry_count++;
+	}
+
+	return ret;
+}
+
+static inline unsigned long rdtsc(void)
+{
+	uint32_t a, d;
+
+	asm volatile("rdtsc" : "=a"(a), "=d"(d));
+	return ((uint64_t)d << 32) | (uint64_t)a;
+}
+
+static inline void umonitor(volatile void *addr)
+{
+	asm volatile(".byte 0xf3, 0x48, 0x0f, 0xae, 0xf0" : : "a"(addr));
+}
+
+static inline int umwait(unsigned long timeout, unsigned int state)
+{
+	uint8_t r;
+	uint32_t timeout_low = (uint32_t)timeout;
+	uint32_t timeout_high = (uint32_t)(timeout >> 32);
+
+	timeout_low = (uint32_t)timeout;
+	timeout_high = (uint32_t)(timeout >> 32);
+
+	asm volatile(".byte 0xf2, 0x48, 0x0f, 0xae, 0xf1\t\n"
+		"setc %0\t\n"
+		: "=r"(r)
+		: "c"(state), "a"(timeout_low), "d"(timeout_high));
+	return r;
+}
+
+static int dsa_wait_on_desc_timeout(struct dsa_completion_record *comp,
+		unsigned int msec_timeout)
+{
+	unsigned int j = 0;
+
+	if (!umwait_support) {
+		while (j < msec_timeout && comp->status == 0) {
+			usleep(1000);
+			j++;
+		}
+	} else {
+		unsigned long timeout = (ms_timeout * 1000000) * 3;
+		int r = 1;
+		unsigned long t = 0;
+
+		timeout += rdtsc();
+		while (comp->status == 0) {
+			if (!r) {
+				t = rdtsc();
+				if (t >= timeout) {
+					err("umwait timeout %#lx\n", t);
+					break;
+				}
+			}
+
+			umonitor((uint8_t *)comp);
+			if (comp->status != 0)
+				break;
+			r = umwait(timeout, 0);
+		}
+		if (t >= timeout)
+			j = msec_timeout;
+	}
+
+	return (j == msec_timeout) ? -EAGAIN : 0;
+}
+
+/* the pattern is 8 bytes long while the dst can with any length */
+void memset_pattern(void *dst, uint64_t pattern, size_t len)
+{
+	size_t len_8_aligned, len_remainding, mask = 0x7;
+	uint64_t *aligned_end, *tmp_64;
+
+	/* 8 bytes aligned part */
+	len_8_aligned = len & ~mask;
+	aligned_end = (uint64_t *)((uint8_t *)dst + len_8_aligned);
+	tmp_64 = (uint64_t *)dst;
+	while (tmp_64 < aligned_end) {
+		*tmp_64 = pattern;
+		tmp_64++;
+	}
+
+	/* non-aligned part */
+	len_remainding = len & mask;
+	memcpy(aligned_end, &pattern, len_remainding);
+}
+
+/* return 0 if src is a repeatation of pattern, -1 otherwise */
+/* the pattern is 8 bytes long and the src could be with any length */
+int memcmp_pattern(const void *src, const uint64_t pattern, size_t len)
+{
+	size_t len_8_aligned, len_remainding, mask = 0x7;
+	uint64_t *aligned_end, *tmp_64;
+
+	/* 8 bytes aligned part */
+	len_8_aligned = len & ~mask;
+	aligned_end = (uint64_t *)((uint8_t *)src + len_8_aligned);
+	tmp_64 = (uint64_t *)src;
+	while (tmp_64 < aligned_end) {
+		if (*tmp_64 != pattern)
+			return -1;
+		tmp_64++;
+	}
+
+	/* non-aligned part */
+	len_remainding = len & mask;
+	if (memcmp(aligned_end, &pattern, len_remainding))
+		return -1;
+
+	return 0;
+}
+
+void dsa_free(struct dsa_context *ctx)
+{
+	if (munmap(ctx->wq_reg, 0x1000))
+		err("munmap failed %d\n", errno);
+
+	close(ctx->fd);
+
+	accfg_unref(ctx->ctx);
+	dsa_free_task(ctx);
+	free(ctx);
+}
+
+void dsa_free_task(struct dsa_context *ctx)
+{
+	free_task(ctx->single_task);
+}
+
+void free_task(struct task *tsk)
+{
+	clean_task(tsk);
+	free(tsk->desc);
+	free(tsk->comp);
+	free(tsk);
+}
+
+/* The components of task is free but not the struct task itself */
+void clean_task(struct task *tsk)
+{
+	if (!tsk)
+		return;
+
+	free(tsk->src2);
+	free(tsk->dst1);
+	free(tsk->dst2);
+}
+
+int dsa_wait_crcgen(struct dsa_context *ctx)
+{
+	struct dsa_hw_desc *desc = ctx->single_task->desc;
+	struct dsa_completion_record *comp = ctx->single_task->comp;
+	int rc;
+
+again:
+	rc = dsa_wait_on_desc_timeout(comp, ms_timeout);
+
+	if (rc < 0) {
+		err("crcgen desc timeout\n");
+		return DSA_STATUS_TIMEOUT;
+	}
+
+	/* re-submit if PAGE_FAULT reported by HW && BOF is off */
+	if (stat_val(comp->status) == DSA_COMP_PAGE_FAULT_NOBOF &&
+			!(desc->flags & IDXD_OP_FLAG_BOF)) {
+		dsa_reprep_crcgen(ctx);
+		goto again;
+	}
+
+	return DSA_STATUS_OK;
+}
+
+int dsa_crcgen(struct dsa_context *ctx)
+{
+	struct task *tsk = ctx->single_task;
+	int ret = DSA_STATUS_OK;
+
+	//tsk->dflags = 0x0;
+	tsk->dflags = IDXD_OP_FLAG_CRAV | IDXD_OP_FLAG_RCR ;
+	if ((tsk->test_flags & TEST_FLAGS_BOF) && ctx->bof)
+		tsk->dflags |= IDXD_OP_FLAG_BOF;
+
+	dsa_prep_crcgen(tsk);
+	dsa_desc_submit(ctx, tsk->desc);
+	ret = dsa_wait_crcgen(ctx);
+
+	return ret;
+}
+
+int dsa_wait_copycrc(struct dsa_context *ctx)
+{
+	struct dsa_hw_desc *desc = ctx->single_task->desc;
+	struct dsa_completion_record *comp = ctx->single_task->comp;
+	int rc;
+
+again:
+	rc = dsa_wait_on_desc_timeout(comp, ms_timeout);
+
+	if (rc < 0) {
+		err("copy crc desc timeout\n");
+		return DSA_STATUS_TIMEOUT;
+	}
+
+	/* re-submit if PAGE_FAULT reported by HW && BOF is off */
+	if (stat_val(comp->status) == DSA_COMP_PAGE_FAULT_NOBOF &&
+			!(desc->flags & IDXD_OP_FLAG_BOF)) {
+		dsa_reprep_copycrc(ctx);
+		goto again;
+	}
+
+	return DSA_STATUS_OK;
+}
+
+int dsa_copycrc(struct dsa_context *ctx)
+{
+	struct task *tsk = ctx->single_task;
+	int ret = DSA_STATUS_OK;
+
+	tsk->dflags = IDXD_OP_FLAG_CRAV | IDXD_OP_FLAG_RCR;
+	if ((tsk->test_flags & TEST_FLAGS_BOF) && ctx->bof)
+		tsk->dflags |= IDXD_OP_FLAG_BOF;
+
+	dsa_prep_copycrc(tsk);
+	dsa_desc_submit(ctx, tsk->desc);
+	ret = dsa_wait_copycrc(ctx);
+
+	return ret;
+}
+
+/* mismatch_expected: expect mismatched buffer with success status 0x1 */
+int task_result_verify(struct task *tsk, int mismatch_expected)
+{
+	int rc;
+
+	//info("verifying task result for %#lx\n", tsk);
+
+	if (tsk->comp->status != DSA_COMP_SUCCESS)
+		return tsk->comp->status;
+
+	switch (tsk->opcode) {
+	case DSA_OPCODE_CRCGEN:
+		rc = task_result_verify_crcgen(tsk, mismatch_expected);
+		return rc;
+	case DSA_OPCODE_COPY_CRC:
+		rc = task_result_verify_copycrc(tsk, mismatch_expected);
+		return rc;
+	}
+
+	info("test with op %d passed\n", tsk->opcode);
+
+	return DSA_STATUS_OK;
+}
+
+int task_result_verify_crcgen(struct task *tsk, int mismatch_expected)
+{
+	if (mismatch_expected)
+		warn("invalid arg mismatch_expected for %d\n", tsk->opcode);
+
+	/* crc completed */
+	if (tsk->comp->status) {
+		//info("crc_val=%#x\n", tsk->comp->crc_val);
+		return DSA_STATUS_OK;
+	}
+
+	err("DSA wrongly cal the buffer\n");
+	return -ENXIO;
+}
+
+int task_result_verify_copycrc(struct task *tsk, int mismatch_expected)
+{
+	if (mismatch_expected)
+		warn("invalid arg mismatch_expected for %d\n", tsk->opcode);
+
+	/* crc completed */
+	if (tsk->comp->status) {
+		info("crc_val=%#x\n", tsk->comp->crc_val);
+		return DSA_STATUS_OK;
+	}
+
+	err("DSA wrongly cal the buffer\n");
+	return -ENXIO;
+}
+
+void dsa_prep_desc_common(struct dsa_hw_desc *hw, char opcode,
+		uint64_t dest, uint64_t src, size_t len, unsigned long dflags)
+{
+	hw->flags = dflags;
+	hw->opcode = opcode;
+	hw->src_addr = src;
+	//hw->dst_addr = dest;
+	hw->xfer_size = len;
+}
+
+void dsa_desc_submit(struct dsa_context *ctx, struct dsa_hw_desc *hw)
+{
+	dump_desc(hw);
+
+	/* use MOVDIR64B for DWQ */
+	if (ctx->dedicated)
+		movdir64b(ctx->wq_reg, hw);
+	else /* use ENQCMD for SWQ */
+		if (dsa_enqcmd(ctx, hw))
+			usleep(10000);
+}
+
+void dsa_prep_crcgen(struct task *tsk)
+{
+	struct dsa_hw_desc *hw = tsk->desc;
+	//info("preparing descriptor for crcgen\n");
+
+	dsa_prep_desc_common(tsk->desc, tsk->opcode, (uint64_t)(tsk->dst1),
+			(uint64_t)(tsk->src1), tsk->xfer_size, tsk->dflags);
+	hw->crc_seed = tsk->crc_seed;
+	tsk->desc->completion_addr = (uint64_t)(tsk->comp);
+	tsk->comp->status = 0;
+}
+
+void dsa_prep_copycrc(struct task *tsk)
+{
+	struct dsa_hw_desc *hw = tsk->desc;
+	info("preparing descriptor for copycrc\n");
+
+	dsa_prep_desc_common(tsk->desc, tsk->opcode, (uint64_t)(tsk->dst1),
+			(uint64_t)(tsk->src1), tsk->xfer_size, tsk->dflags);
+	hw->seed_addr = (uint64_t)(tsk->seed_addr);
+	hw->crc_seed = tsk->crc_seed;
+	tsk->desc->completion_addr = (uint64_t)(tsk->comp);
+	tsk->comp->status = 0;
+}
+
+void dsa_reprep_crcgen(struct dsa_context *ctx)
+{
+	struct task *tsk = ctx->single_task;
+	struct dsa_completion_record *compr = tsk->comp;
+	struct dsa_hw_desc *hw = ctx->single_task->desc;
+
+	info("PF addr %#lx dir %d bc %#x\n",
+			compr->fault_addr, compr->result,
+			compr->bytes_completed);
+
+	hw->xfer_size -= compr->bytes_completed;
+
+	if (compr->result == 0) {
+		hw->src_addr += compr->bytes_completed;
+	}
+
+	resolve_page_fault(compr->fault_addr, compr->status);
+
+	compr->status = 0;
+
+	dsa_desc_submit(ctx, hw);
+}
+
+void dsa_reprep_copycrc(struct dsa_context *ctx)
+{
+	struct dsa_completion_record *compr = ctx->single_task->comp;
+	struct dsa_hw_desc *hw = ctx->single_task->desc;
+
+	info("PF addr %#lx dir %d bc %#x\n",
+			compr->fault_addr, compr->result,
+			compr->bytes_completed);
+
+	hw->xfer_size -= compr->bytes_completed;
+
+	if (compr->result == 0) {
+		hw->src_addr += compr->bytes_completed;
+		hw->dst_addr += compr->bytes_completed;
+	}
+
+	resolve_page_fault(compr->fault_addr, compr->status);
+
+	compr->status = 0;
+
+	dsa_desc_submit(ctx, hw);
+}

--- a/src/overlaybd/fs/zfile/crc32/dsa.h
+++ b/src/overlaybd/fs/zfile/crc32/dsa.h
@@ -1,0 +1,261 @@
+/* SPDX-License-Identifier: GPL-2.0 */
+/* Copyright(c) 2019 Intel Corporation. All rights reserved. */
+#ifndef __DSA_H__
+#define __DSA_H__
+#include "libaccel_config.h"
+#include "idxd.h"
+
+#define MAX_PATH_LENGTH 1024
+
+#define DSA_MAX_OPS 0x20
+
+#define TEST_FLAGS_BOF     0x1     /* Block on page faults */
+#define TEST_FLAGS_WAIT    0x4     /* Wait in kernel */
+#define TEST_FLAGS_PREF    0x8     /* Pre-fault the buffers */
+
+#define DSA_STATUS_OK    0x0
+#define DSA_STATUS_RETRY 0x1
+#define DSA_STATUS_FAIL  0x2
+#define DSA_STATUS_RPF   0x3
+#define DSA_STATUS_URPF  0x4
+#define DSA_STATUS_TIMEOUT 0x5
+
+#define DSA_CAP_BLOCK_ON_FAULT                  0x0000000000000001
+#define DSA_CAP_OVERLAP_COPY                    0x0000000000000002
+#define DSA_CAP_CACHE_MEM_CTRL                  0x0000000000000004
+#define DSA_CAP_CACHE_FLUSH_CTRL                0x0000000000000008
+#define DSA_CAP_DEST_RDBACK                     0x0000000000000100
+#define DSA_CAP_DUR_WRITE                       0x0000000000000200
+
+#define DSA_CAP_MAX_XFER_MASK                   0x00000000001F0000
+#define DSA_CAP_MAX_XFER_SHIFT                  16
+
+#define DSA_COMP_STAT_CODE_MASK                 0x3F
+#define DSA_COMP_STAT_RW_MASK                   0x80
+#define SHARED 1
+
+/* helper macro to get lower 6 bits (ret code) from completion status */
+#define stat_val(status) ((status) & DSA_COMP_STAT_CODE_MASK)
+
+extern unsigned int ms_timeout;
+extern int debug_logging;
+
+/*
+ * The status field will be modified by hardware, therefore it should be
+ * __volatile__ and prevent the compiler from optimize the read.
+ */
+struct dsa_completion_record {
+	__volatile__ uint8_t	status;
+	union {
+		uint8_t		result;
+		uint8_t		dif_status;
+	};
+	uint16_t		rsvd;
+	uint32_t		bytes_completed;
+	uint64_t		fault_addr;
+	union {
+		/* common record */
+		struct {
+			uint32_t	invalid_flags:24;
+			uint32_t	rsvd2:8;
+		};
+
+		uint32_t	delta_rec_size;
+		uint32_t	crc_val;
+
+		/* DIF check & strip */
+		struct {
+			uint32_t	dif_chk_ref_tag;
+			uint16_t	dif_chk_app_tag_mask;
+			uint16_t	dif_chk_app_tag;
+		};
+
+		/* DIF insert */
+		struct {
+			uint64_t	dif_ins_res;
+			uint32_t	dif_ins_ref_tag;
+			uint16_t	dif_ins_app_tag_mask;
+			uint16_t	dif_ins_app_tag;
+		};
+
+		/* DIF update */
+		struct {
+			uint32_t	dif_upd_src_ref_tag;
+			uint16_t	dif_upd_src_app_tag_mask;
+			uint16_t	dif_upd_src_app_tag;
+			uint32_t	dif_upd_dest_ref_tag;
+			uint16_t	dif_upd_dest_app_tag_mask;
+			uint16_t	dif_upd_dest_app_tag;
+		};
+
+		uint8_t		op_specific[16];
+	};
+} __attribute__((packed));
+
+/* metadata for single DSA task */
+struct task {
+	struct dsa_hw_desc *desc;
+	struct dsa_completion_record *comp;
+	uint32_t opcode;
+	void *src1;
+	void *src2;
+	void *dst1;
+	void *dst2;
+	void *seed_addr;
+	uint32_t crc_seed;
+	uint64_t pattern;
+	uint64_t xfer_size;
+	uint32_t dflags;
+	int test_flags;
+};
+
+struct dsa_context {
+	struct accfg_ctx *ctx;
+	struct accfg_wq *wq;
+
+	unsigned int max_batch_size;
+	unsigned int max_xfer_size;
+	unsigned int max_xfer_bits;
+
+	int fd;
+	int wq_idx;
+	void *wq_reg;
+	int wq_size;
+	int dedicated;
+	int bof;
+	unsigned int wq_max_batch_size;
+	unsigned long wq_max_xfer_size;
+	int ats_disable;
+
+	struct task *single_task;
+};
+
+static inline void vprint_log(const char *tag, const char *msg, va_list args)
+{
+	printf("[%5s] ", tag);
+	vprintf(msg, args);
+}
+
+static inline void vprint_err(const char *tag, const char *msg, va_list args)
+{
+	fprintf(stderr, "[%5s] ", tag);
+	vfprintf(stderr, msg, args);
+}
+
+static inline void err(const char *msg, ...)
+{
+	va_list args;
+
+	va_start(args, msg);
+	vprint_err("error", msg, args);
+	va_end(args);
+}
+
+static inline void warn(const char *msg, ...)
+{
+	va_list args;
+
+	va_start(args, msg);
+	vprint_err("warn", msg, args);
+	va_end(args);
+}
+
+static inline void info(const char *msg, ...)
+{
+	va_list args;
+
+	va_start(args, msg);
+	vprint_log("info", msg, args);
+	va_end(args);
+}
+
+static inline void dbg(const char *msg, ...)
+{
+	va_list args;
+
+	if (!debug_logging)
+		return;
+
+	va_start(args, msg);
+	vprint_log("debug", msg, args);
+	va_end(args);
+}
+
+/* Dump DSA hardware descriptor to log */
+static inline void dump_desc(struct dsa_hw_desc *hw)
+{
+	struct dsa_raw_desc *rhw = (struct dsa_raw_desc *)hw;
+	int i;
+
+	dbg("desc addr: %p\n", hw);
+
+	for (i = 0; i < 8; i++)
+		dbg("desc[%d]: 0x%016lx\n", i, rhw->field[i]);
+}
+
+static inline void resolve_page_fault(uint64_t addr, uint8_t status)
+{
+	uint8_t *addr_u8 = (uint8_t *)addr;
+
+	/* This line solve the PF by writing to the address.*/
+	/* For PF at write, we can change the value as the address will be */
+	/* overwritten again by the DSA HW */
+	*addr_u8 =  ~(*addr_u8);
+
+	/* For PF at read, we need to restore it to the orginal value */
+	if (!(status & DSA_COMP_STAT_RW_MASK))
+		*addr_u8 = ~(*addr_u8);
+}
+
+void memset_pattern(void *dst, uint64_t pattern, size_t len);
+int memcmp_pattern(const void *src, const uint64_t pattern, size_t len);
+int dsa_enqcmd(struct dsa_context *ctx, struct dsa_hw_desc *hw);
+
+struct dsa_context *dsa_init(void);
+int dsa_alloc(struct dsa_context *ctx, int shared);
+int alloc_task(struct dsa_context *ctx);
+struct task *__alloc_task(void);
+int init_task(struct task *tsk, int tflags, int opcode,
+		const uint8_t *data, unsigned long xfer_size, uint32_t crc_seed);
+
+int dsa_crcgen(struct dsa_context *ctx);
+int dsa_copycrc(struct dsa_context *ctx);
+int dsa_wait_crcgen(struct dsa_context *ctx);
+int dsa_wait_copycrc(struct dsa_context *ctx);
+
+
+void dsa_prep_crcgen(struct task *tsk);
+void dsa_reprep_crcgen(struct dsa_context *ctx);
+void dsa_prep_copycrc(struct task *tsk);
+void dsa_reprep_copycrc(struct dsa_context *ctx);
+
+int task_result_verify(struct task *tsk, int mismatch_expected);
+int task_result_verify_crcgen(struct task *tsk, int mismatch_expected);
+int task_result_verify_copycrc(struct task *tsk, int mismatch_expected);
+
+void dsa_free(struct dsa_context *ctx);
+void dsa_free_task(struct dsa_context *ctx);
+void free_task(struct task *tsk);
+void clean_task(struct task *tsk);
+
+void dsa_prep_desc_common(struct dsa_hw_desc *hw, char opcode,
+		uint64_t dest, uint64_t src, size_t len, unsigned long dflags);
+void dsa_desc_submit(struct dsa_context *ctx, struct dsa_hw_desc *hw);
+
+static inline void movdir64b(volatile void *portal, void *desc)
+{
+	asm volatile("sfence\t\n"
+			".byte 0x66, 0x0f, 0x38, 0xf8, 0x02\t\n"  :
+			: "a" (portal), "d" (desc));
+}
+
+static inline unsigned char enqcmd(volatile void *portal, void *desc)
+{
+	unsigned char retry;
+	asm volatile("sfence\t\n"
+			".byte 0xf2, 0x0f, 0x38, 0xf8, 0x02\t\n"
+			"setz %0\t\n"
+			: "=r"(retry): "a" (portal), "d" (desc));
+	return retry;
+}
+#endif

--- a/src/overlaybd/fs/zfile/crc32/idxd.h
+++ b/src/overlaybd/fs/zfile/crc32/idxd.h
@@ -1,0 +1,273 @@
+/* SPDX-License-Identifier: LGPL-2.1 */
+/*   Copyright(c) 2019 Intel Corporation. All rights reserved. */
+
+#ifndef _USR_IDXD_H_
+#define _USR_IDXD_H_
+#include <stdint.h>
+
+/* Driver command error status */
+enum idxd_scmd_stat {
+	IDXD_SCMD_DEV_ENABLED = 0x80000010,
+	IDXD_SCMD_DEV_NOT_ENABLED = 0x80000020,
+	IDXD_SCMD_WQ_ENABLED = 0x80000021,
+	IDXD_SCMD_DEV_DMA_ERR = 0x80020000,
+	IDXD_SCMD_WQ_NO_GRP = 0x80030000,
+	IDXD_SCMD_WQ_NO_NAME = 0x80040000,
+	IDXD_SCMD_WQ_NO_SVM = 0x80050000,
+	IDXD_SCMD_WQ_NO_THRESH = 0x80060000,
+	IDXD_SCMD_WQ_PORTAL_ERR = 0x80070000,
+	IDXD_SCMD_WQ_RES_ALLOC_ERR = 0x80080000,
+	IDXD_SCMD_PERCPU_ERR = 0x80090000,
+	IDXD_SCMD_DMA_CHAN_ERR = 0x800a0000,
+	IDXD_SCMD_CDEV_ERR = 0x800b0000,
+	IDXD_SCMD_WQ_NO_SWQ_SUPPORT = 0x800c0000,
+	IDXD_SCMD_WQ_NONE_CONFIGURED = 0x800d0000,
+	IDXD_SCMD_WQ_NO_SIZE = 0x800e0000,
+};
+
+#define IDXD_SCMD_SOFTERR_MASK	0x80000000
+#define IDXD_SCMD_SOFTERR_SHIFT	16
+
+/* Descriptor flags */
+#define IDXD_OP_FLAG_FENCE	0x0001
+#define IDXD_OP_FLAG_BOF	0x0002
+#define IDXD_OP_FLAG_CRAV	0x0004
+#define IDXD_OP_FLAG_RCR	0x0008
+#define IDXD_OP_FLAG_RCI	0x0010
+#define IDXD_OP_FLAG_CRSTS	0x0020
+#define IDXD_OP_FLAG_CR		0x0080
+#define IDXD_OP_FLAG_CC		0x0100
+#define IDXD_OP_FLAG_ADDR1_TCS	0x0200
+#define IDXD_OP_FLAG_ADDR2_TCS	0x0400
+#define IDXD_OP_FLAG_ADDR3_TCS	0x0800
+#define IDXD_OP_FLAG_CR_TCS	0x1000
+#define IDXD_OP_FLAG_STORD	0x2000
+#define IDXD_OP_FLAG_DRDBK	0x4000
+#define IDXD_OP_FLAG_DSTS	0x8000
+
+/* IAX */
+#define IDXD_OP_FLAG_RD_SRC2_AECS	0x010000
+
+/* Opcode */
+enum dsa_opcode {
+	DSA_OPCODE_NOOP = 0,
+	DSA_OPCODE_BATCH,
+	DSA_OPCODE_DRAIN,
+	DSA_OPCODE_MEMMOVE,
+	DSA_OPCODE_MEMFILL,
+	DSA_OPCODE_COMPARE,
+	DSA_OPCODE_COMPVAL,
+	DSA_OPCODE_CR_DELTA,
+	DSA_OPCODE_AP_DELTA,
+	DSA_OPCODE_DUALCAST,
+	DSA_OPCODE_CRCGEN = 0x10,
+	DSA_OPCODE_COPY_CRC,
+	DSA_OPCODE_DIF_CHECK,
+	DSA_OPCODE_DIF_INS,
+	DSA_OPCODE_DIF_STRP,
+	DSA_OPCODE_DIF_UPDT,
+	DSA_OPCODE_CFLUSH = 0x20,
+};
+
+enum iax_opcode {
+	IAX_OPCODE_NOOP = 0,
+	IAX_OPCODE_DRAIN = 2,
+	IAX_OPCODE_MEMMOVE,
+	IAX_OPCODE_DECOMPRESS = 0x42,
+	IAX_OPCODE_COMPRESS,
+};
+
+/* Completion record status */
+enum dsa_completion_status {
+	DSA_COMP_NONE = 0,
+	DSA_COMP_SUCCESS,
+	DSA_COMP_SUCCESS_PRED,
+	DSA_COMP_PAGE_FAULT_NOBOF,
+	DSA_COMP_PAGE_FAULT_IR,
+	DSA_COMP_BATCH_FAIL,
+	DSA_COMP_BATCH_PAGE_FAULT,
+	DSA_COMP_DR_OFFSET_NOINC,
+	DSA_COMP_DR_OFFSET_ERANGE,
+	DSA_COMP_DIF_ERR,
+	DSA_COMP_BAD_OPCODE = 0x10,
+	DSA_COMP_INVALID_FLAGS,
+	DSA_COMP_NOZERO_RESERVE,
+	DSA_COMP_XFER_ERANGE,
+	DSA_COMP_DESC_CNT_ERANGE,
+	DSA_COMP_DR_ERANGE,
+	DSA_COMP_OVERLAP_BUFFERS,
+	DSA_COMP_DCAST_ERR,
+	DSA_COMP_DESCLIST_ALIGN,
+	DSA_COMP_INT_HANDLE_INVAL,
+	DSA_COMP_CRA_XLAT,
+	DSA_COMP_CRA_ALIGN,
+	DSA_COMP_ADDR_ALIGN,
+	DSA_COMP_PRIV_BAD,
+	DSA_COMP_TRAFFIC_CLASS_CONF,
+	DSA_COMP_PFAULT_RDBA,
+	DSA_COMP_HW_ERR1,
+	DSA_COMP_HW_ERR_DRB,
+	DSA_COMP_TRANSLATION_FAIL,
+};
+
+enum iax_completion_status {
+	IAX_COMP_NONE = 0,
+	IAX_COMP_SUCCESS,
+	IAX_COMP_PAGE_FAULT_IR = 0x04,
+	IAX_COMP_OUTBUF_OVERFLOW,
+	IAX_COMP_BAD_OPCODE = 0x10,
+	IAX_COMP_INVALID_FLAGS,
+	IAX_COMP_NOZERO_RESERVE,
+	IAX_COMP_INVALID_SIZE,
+	IAX_COMP_OVERLAP_BUFFERS = 0x16,
+	IAX_COMP_INT_HANDLE_INVAL = 0x19,
+	IAX_COMP_CRA_XLAT,
+	IAX_COMP_CRA_ALIGN,
+	IAX_COMP_ADDR_ALIGN,
+	IAX_COMP_PRIV_BAD,
+	IAX_COMP_TRAFFIC_CLASS_CONF,
+	IAX_COMP_PFAULT_RDBA,
+	IAX_COMP_HW_ERR1,
+	IAX_COMP_HW_ERR_DRB,
+	IAX_COMP_TRANSLATION_FAIL,
+	IAX_COMP_PRS_TIMEOUT,
+	IAX_COMP_WATCHDOG,
+	IAX_COMP_INVALID_COMP_FLAG = 0x30,
+	IAX_COMP_INVALID_FILTER_FLAG,
+	IAX_COMP_INVALID_NUM_ELEMS = 0x33,
+};
+
+#define DSA_COMP_STATUS_MASK		0x7f
+#define DSA_COMP_STATUS_WRITE		0x80
+
+struct dsa_hw_desc {
+	uint32_t	pasid:20;
+	uint32_t	rsvd:11;
+	uint32_t	priv:1;
+	uint32_t	flags:24;
+	uint32_t	opcode:8;
+	uint64_t	completion_addr;
+	union {
+		uint64_t	src_addr;
+		uint64_t	rdback_addr;
+		uint64_t	pattern;
+		uint64_t	desc_list_addr;
+	};
+	union {
+		uint64_t	dst_addr;
+		uint64_t	rdback_addr2;
+		uint64_t	src2_addr;
+		uint64_t	comp_pattern;
+	};
+	union {
+		uint32_t	xfer_size;
+		uint32_t	desc_count;
+	};
+	uint16_t	int_handle;
+	uint16_t	rsvd1;
+	union {
+		uint8_t		expected_res;
+		/* create delta record */
+		struct {
+			uint64_t	delta_addr;
+			uint32_t	max_delta_size;
+			uint32_t	delt_rsvd;
+			uint8_t		expected_res_mask;
+		};
+		uint32_t	delta_rec_size;
+		uint64_t	dest2;
+		/* CRC */
+		struct {
+			uint32_t	crc_seed;
+			uint32_t	crc_rsvd;
+			uint64_t	seed_addr;
+		};
+		/* DIF check or strip */
+		struct {
+			uint8_t		src_dif_flags;
+			uint8_t		dif_chk_res;
+			uint8_t		dif_chk_flags;
+			uint8_t		dif_chk_res2[5];
+			uint32_t	chk_ref_tag_seed;
+			uint16_t	chk_app_tag_mask;
+			uint16_t	chk_app_tag_seed;
+		};
+		/* DIF insert */
+		struct {
+			uint8_t		dif_ins_res;
+			uint8_t		dest_dif_flag;
+			uint8_t		dif_ins_flags;
+			uint8_t		dif_ins_res2[13];
+			uint32_t	ins_ref_tag_seed;
+			uint16_t	ins_app_tag_mask;
+			uint16_t	ins_app_tag_seed;
+		};
+		/* DIF update */
+		struct {
+			uint8_t		src_upd_flags;
+			uint8_t		upd_dest_flags;
+			uint8_t		dif_upd_flags;
+			uint8_t		dif_upd_res[5];
+			uint32_t	src_ref_tag_seed;
+			uint16_t	src_app_tag_mask;
+			uint16_t	src_app_tag_seed;
+			uint32_t	dest_ref_tag_seed;
+			uint16_t	dest_app_tag_mask;
+			uint16_t	dest_app_tag_seed;
+		};
+
+		uint8_t		op_specific[24];
+	};
+} __attribute__((packed));
+
+struct iax_hw_desc {
+	uint32_t        pasid:20;
+	uint32_t        rsvd:11;
+	uint32_t        priv:1;
+	uint32_t        flags:24;
+	uint32_t        opcode:8;
+	uint64_t        completion_addr;
+	uint64_t        src1_addr;
+	uint64_t        dst_addr;
+	uint32_t        src1_size;
+	uint16_t        int_handle;
+	union {
+		uint16_t        compr_flags;
+		uint16_t        decompr_flags;
+	};
+	uint64_t        src2_addr;
+	uint32_t        max_dst_size;
+	uint32_t        src2_size;
+	uint32_t	filter_flags;
+	uint32_t	num_inputs;
+} __attribute__((packed));
+
+struct dsa_raw_desc {
+	uint64_t	field[8];
+} __attribute__((packed));
+
+
+
+struct dsa_raw_completion_record {
+	uint64_t	field[4];
+} __attribute__((packed));
+
+struct iax_completion_record {
+	__volatile__ uint8_t        status;
+	uint8_t                 error_code;
+	uint16_t                rsvd;
+	uint32_t                bytes_completed;
+	uint64_t                fault_addr;
+	uint32_t                invalid_flags;
+	uint32_t                rsvd2;
+	uint32_t                output_size;
+	uint8_t                 output_bits;
+	uint8_t                 rsvd3;
+	uint16_t                rsvd4;
+	uint64_t                rsvd5[4];
+} __attribute__((packed));
+
+struct iax_raw_completion_record {
+	uint64_t	field[8];
+} __attribute__((packed));
+#endif

--- a/src/overlaybd/fs/zfile/crc32/libaccel_config.h
+++ b/src/overlaybd/fs/zfile/crc32/libaccel_config.h
@@ -1,0 +1,320 @@
+// SPDX-License-Identifier: LGPL-2.1
+/* Copyright(c) 2019 Intel Corporation. All rights reserved. */
+
+#ifndef _LIBACCFG_H_
+#define _LIBACCFG_H_
+
+#include <stdbool.h>
+#include <stdarg.h>
+#include <stdint.h>
+#include <unistd.h>
+#include <errno.h>
+#include <limits.h>
+#include <uuid/uuid.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#ifndef UUID_STR_LEN
+#define UUID_STR_LEN 37
+#endif
+
+#define MAX_DEV_LEN 64
+#define MAX_BUF_LEN 128
+#define MAX_PARAM_LEN 64
+#define TRAFFIC_CLASS_LIMIT 8
+#define WQ_PRIORITY_LIMIT 15
+#define UUID_ZERO "00000000-0000-0000-0000-000000000000"
+
+enum accfg_device_version {
+	ACCFG_DEVICE_VERSION_1 = 0x100,
+	ACCFG_DEVICE_VERSION_2 = 0x200,
+};
+
+/* no need to save device state */
+enum accfg_device_type {
+	ACCFG_DEVICE_DSA = 0,
+	ACCFG_DEVICE_IAX = 1,
+	ACCFG_DEVICE_TYPE_UNKNOWN = -1,
+};
+
+enum accfg_device_state {
+	ACCFG_DEVICE_DISABLED = 0,
+	ACCFG_DEVICE_ENABLED = 1,
+	ACCFG_DEVICE_UNKNOWN = -1,
+};
+
+enum accfg_wq_mode {
+	ACCFG_WQ_SHARED = 0,
+	ACCFG_WQ_DEDICATED,
+	ACCFG_WQ_MODE_UNKNOWN,
+};
+
+enum accfg_wq_state {
+	ACCFG_WQ_DISABLED,
+	ACCFG_WQ_ENABLED,
+	ACCFG_WQ_QUIESCING,
+	ACCFG_WQ_LOCKED,
+	ACCFG_WQ_UNKNOWN = -1,
+};
+
+enum accfg_wq_type {
+	ACCFG_WQT_NONE = 0,
+	ACCFG_WQT_KERNEL,
+	ACCFG_WQT_USER,
+	ACCFG_WQT_MDEV,
+};
+
+enum accfg_control_flag {
+	ACCFG_DEVICE_DISABLE = 0,
+	ACCFG_DEVICE_ENABLE,
+	ACCFG_WQ_ENABLE,
+	ACCFG_WQ_DISABLE,
+};
+
+enum accfg_mdev_type {
+	ACCFG_MDEV_TYPE_1_DWQ,
+	ACCFG_MDEV_TYPE_1_SWQ,
+	ACCFG_MDEV_TYPE_UNKNOWN,
+};
+
+/* no need to save device error */
+struct accfg_error {
+	uint64_t val[4];
+};
+
+struct accfg_op_cap {
+	uint64_t bits[4];
+};
+
+/* parameters read from sysfs of accfg driver */
+struct dev_parameters {
+	unsigned int token_limit;
+};
+
+extern char *accfg_basenames[];
+extern char *accfg_mdev_basenames[];
+
+struct group_parameters {
+	unsigned int tokens_reserved;
+	unsigned int tokens_allowed;
+	unsigned int use_token_limit;
+	int traffic_class_a;
+	int traffic_class_b;
+};
+
+struct wq_parameters {
+	int group_id;
+	unsigned int wq_size;
+	unsigned int threshold;
+	unsigned int priority;
+	int block_on_fault;
+	unsigned int max_batch_size;
+	uint64_t max_transfer_size;
+	int ats_disable;
+	const char *mode;
+	const char *type;
+	const char *name;
+};
+
+struct engine_parameters {
+	int group_id;
+};
+
+struct accfg_ctx;
+
+/* Retrieve current library loglevel */
+int accfg_get_log_priority(struct accfg_ctx *ctx);
+
+/* Set log level */
+void accfg_set_log_priority(struct accfg_ctx *ctx, int priority);
+
+/* instantiate a new library context */
+struct accfg_ctx *accfg_ref(struct accfg_ctx *ctx);
+
+/* drop a context reference count */
+struct accfg_ctx *accfg_unref(struct accfg_ctx *ctx);
+
+/* instantiate a new library context */
+int accfg_new(struct accfg_ctx **ctx);
+
+/* override default log routine */
+void accfg_set_log_fn(struct accfg_ctx *ctx,
+void (*log_fn)(struct accfg_ctx *ctx,
+	       int priority, const char *file,
+	       int line, const char *fn,
+	       const char *format,
+	       va_list args));
+
+/* libaccfg function for device */
+struct accfg_device;
+/* Helper function to enable/disable the part in device */
+int accfg_device_enable(struct accfg_device *device);
+int accfg_device_disable(struct accfg_device *device, bool force);
+
+/* Helper function to double check the state of the device/wq after enable/disable */
+struct accfg_device *accfg_device_get_first(struct accfg_ctx *ctx);
+struct accfg_device *accfg_device_get_next(struct accfg_device *device);
+#define accfg_device_foreach(ctx, device) \
+	for (device = accfg_device_get_first(ctx); \
+	     device != NULL; \
+	     device = accfg_device_get_next(device))
+struct accfg_ctx *accfg_device_get_ctx(struct accfg_device *);
+const char *accfg_device_get_devname(struct accfg_device *device);
+int accfg_device_type_validate(const char *dev_name);
+enum accfg_device_type accfg_device_get_type(struct accfg_device *device);
+char *accfg_device_get_type_str(struct accfg_device *device);
+int accfg_device_get_id(struct accfg_device *device);
+struct accfg_device *accfg_ctx_device_get_by_id(struct accfg_ctx *ctx,
+		int id);
+struct accfg_device *accfg_ctx_device_get_by_name(struct accfg_ctx *ctx,
+		const char *dev_name);
+unsigned int accfg_device_get_max_groups(struct accfg_device *device);
+unsigned int accfg_device_get_max_work_queues(struct accfg_device *device);
+unsigned int accfg_device_get_max_engines(struct accfg_device *device);
+unsigned int accfg_device_get_max_work_queues_size(struct accfg_device *device);
+int accfg_device_get_numa_node(struct accfg_device *device);
+unsigned int accfg_device_get_ims_size(struct accfg_device *device);
+unsigned int accfg_device_get_max_batch_size(struct accfg_device *device);
+uint64_t accfg_device_get_max_transfer_size(struct accfg_device *device);
+int accfg_device_get_op_cap(struct accfg_device *device,
+		struct accfg_op_cap *op_cap);
+uint64_t accfg_device_get_gen_cap(struct accfg_device *device);
+unsigned int accfg_device_get_configurable(struct accfg_device *device);
+bool accfg_device_get_pasid_enabled(struct accfg_device  *device);
+bool accfg_device_get_mdev_enabled(struct accfg_device *device);
+int accfg_device_get_errors(struct accfg_device *device, struct accfg_error *error);
+enum accfg_device_state accfg_device_get_state(struct accfg_device *device);
+unsigned int accfg_device_get_max_tokens(struct accfg_device *device);
+unsigned int accfg_device_get_max_batch_size(struct accfg_device *device);
+unsigned int accfg_device_get_token_limit(struct accfg_device *device);
+unsigned int accfg_device_get_cdev_major(struct accfg_device *device);
+unsigned int accfg_device_get_version(struct accfg_device *device);
+int accfg_device_get_clients(struct accfg_device *device);
+int accfg_device_set_token_limit(struct accfg_device *dev, int val);
+int accfg_device_is_active(struct accfg_device *device);
+unsigned int accfg_device_get_cmd_status(struct accfg_device *device);
+const char *accfg_device_get_cmd_status_str(struct accfg_device *device);
+unsigned int accfg_ctx_get_last_error(struct accfg_ctx *ctx);
+const char *accfg_ctx_get_last_error_str(struct accfg_ctx *ctx);
+struct accfg_device *accfg_ctx_get_last_error_device(struct accfg_ctx *ctx);
+struct accfg_wq *accfg_ctx_get_last_error_wq(struct accfg_ctx *ctx);
+struct accfg_group *accfg_ctx_get_last_error_group(struct accfg_ctx *ctx);
+struct accfg_engine *accfg_ctx_get_last_error_engine(struct accfg_ctx *ctx);
+struct accfg_device_mdev;
+struct accfg_device_mdev *accfg_device_first_mdev(struct accfg_device *device);
+struct accfg_device_mdev *accfg_device_next_mdev(struct accfg_device_mdev *mdev);
+void accfg_mdev_get_uuid(struct accfg_device_mdev *mdev, uuid_t uuid);
+enum accfg_mdev_type accfg_mdev_get_type(struct accfg_device_mdev *mdev);
+int accfg_create_mdev(struct accfg_device *device, enum accfg_mdev_type type,
+		uuid_t uuid);
+int accfg_remove_mdev(struct accfg_device *device, uuid_t uuid);
+
+#define accfg_device_mdev_foreach(device, mdev) \
+	for (mdev = accfg_device_first_mdev(device); \
+		mdev != NULL; \
+		mdev = accfg_device_next_mdev(mdev))
+
+/* libaccfg function for group */
+struct accfg_group;
+struct accfg_group *accfg_group_get_first(struct accfg_device *device);
+struct accfg_group *accfg_group_get_next(struct accfg_group *group);
+#define accfg_group_foreach(device, group) \
+	for (group = accfg_group_get_first(device); \
+	     group != NULL; \
+	     group = accfg_group_get_next(group))
+int accfg_group_get_id(struct accfg_group *group);
+struct accfg_group *accfg_device_group_get_by_id(struct accfg_device *device,
+						int id);
+int accfg_group_get_device_id(struct accfg_group *group);
+const char *accfg_group_get_devname(struct accfg_group *group);
+uint64_t accfg_group_get_size(struct accfg_group *group);
+uint64_t accfg_group_get_available_size(struct accfg_group *group);
+struct accfg_device *accfg_group_get_device(struct accfg_group *group);
+struct accfg_ctx *accfg_group_get_ctx(struct accfg_group *group);
+int accfg_group_get_tokens_reserved(struct accfg_group *group);
+int accfg_group_get_tokens_allowed(struct accfg_group *group);
+int accfg_group_get_use_token_limit(struct accfg_group *group);
+int accfg_group_get_traffic_class_a(struct accfg_group *group);
+int accfg_group_get_traffic_class_b(struct accfg_group *group);
+int accfg_group_set_tokens_reserved(struct accfg_group *group, int val);
+int accfg_group_set_tokens_allowed(struct accfg_group *group, int val);
+int accfg_group_set_use_token_limit(struct accfg_group *group, int val);
+int accfg_group_set_traffic_class_a(struct accfg_group *group, int val);
+int accfg_group_set_traffic_class_b(struct accfg_group *group, int val);
+
+/* libaccfg function for wq */
+struct accfg_wq;
+struct accfg_wq *accfg_wq_get_first(struct accfg_device *device);
+struct accfg_wq *accfg_wq_get_next(struct accfg_wq *wq);
+
+
+#define accfg_wq_foreach(device, wq) \
+	for (wq = accfg_wq_get_first(device); \
+	     wq != NULL; \
+	     wq = accfg_wq_get_next(wq))
+
+struct accfg_ctx *accfg_wq_get_ctx(struct accfg_wq *wq);
+struct accfg_device *accfg_wq_get_device(struct accfg_wq *wq);
+struct accfg_group *accfg_wq_get_group(struct accfg_wq *wq);
+int accfg_wq_get_id(struct accfg_wq *wq);
+struct accfg_wq *accfg_device_wq_get_by_id(struct accfg_device *device,
+					int id);
+const char *accfg_wq_get_devname(struct accfg_wq *wq);
+enum accfg_wq_mode accfg_wq_get_mode(struct accfg_wq *wq);
+uint64_t accfg_wq_get_size(struct accfg_wq *wq);
+int accfg_wq_get_group_id(struct accfg_wq *wq);
+int accfg_wq_get_priority(struct accfg_wq *wq);
+unsigned int accfg_wq_get_priv(struct accfg_wq *wq);
+int accfg_wq_get_block_on_fault(struct accfg_wq *wq);
+enum accfg_wq_state accfg_wq_get_state(struct accfg_wq *wq);
+int accfg_wq_get_cdev_minor(struct accfg_wq *wq);
+const char *accfg_wq_get_type_name(struct accfg_wq *wq);
+enum accfg_wq_type accfg_wq_get_type(struct accfg_wq *wq);
+unsigned int accfg_wq_get_max_batch_size(struct accfg_wq *wq);
+uint64_t accfg_wq_get_max_transfer_size(struct accfg_wq *wq);
+int accfg_wq_get_threshold(struct accfg_wq *wq);
+int accfg_wq_get_clients(struct accfg_wq *wq);
+int accfg_wq_get_ats_disable(struct accfg_wq *wq);
+int accfg_wq_get_occupancy(struct accfg_wq *wq);
+int accfg_wq_is_enabled(struct accfg_wq *wq);
+int accfg_wq_set_size(struct accfg_wq *wq, int val);
+int accfg_wq_set_priority(struct accfg_wq *wq, int val);
+int accfg_wq_set_group_id(struct accfg_wq *wq, int val);
+int accfg_wq_set_threshold(struct accfg_wq *wq, int val);
+int accfg_wq_set_block_on_fault(struct accfg_wq *wq, int val);
+int accfg_wq_set_max_batch_size(struct accfg_wq *wq, int val);
+int accfg_wq_set_ats_disable(struct accfg_wq *wq, int val);
+int accfg_wq_set_max_transfer_size(struct accfg_wq *wq, uint64_t val);
+int accfg_wq_set_str_mode(struct accfg_wq *wq, const char *val);
+int accfg_wq_set_mode(struct accfg_wq *wq, enum accfg_wq_mode mode);
+int accfg_wq_set_str_type(struct accfg_wq *wq, const char *val);
+int accfg_wq_set_str_name(struct accfg_wq *wq, const char *val);
+int accfg_wq_enable(struct accfg_wq *wq);
+int accfg_wq_disable(struct accfg_wq *wq, bool force);
+int accfg_wq_priority_boundary(struct accfg_wq *wq);
+int accfg_wq_size_boundary(struct accfg_device *device, int wq_num);
+int accfg_wq_get_user_dev_path(struct accfg_wq *wq, char *buf, size_t size);
+
+/* libaccfg function for engine */
+struct accfg_engine;
+struct accfg_engine *accfg_engine_get_first(struct accfg_device *device);
+struct accfg_engine *accfg_engine_get_next(struct accfg_engine *engine);
+#define accfg_engine_foreach(device, engine) \
+	for (engine = accfg_engine_get_first(device); \
+	     engine != NULL; \
+	     engine = accfg_engine_get_next(engine))
+struct accfg_ctx *accfg_engine_get_ctx(struct accfg_engine *engine);
+struct accfg_device *accfg_engine_get_device(struct accfg_engine *engine);
+struct accfg_group *accfg_engine_get_group(struct accfg_engine *engine);
+int accfg_engine_get_group_id(struct accfg_engine *engine);
+int accfg_engine_get_id(struct accfg_engine *engine);
+struct accfg_engine *accfg_device_engine_get_by_id(struct accfg_device *device,
+						int id);
+const char *accfg_engine_get_devname(struct accfg_engine *engine);
+int accfg_engine_set_group_id(struct accfg_engine *engine, int val);
+#ifdef __cplusplus
+}				/* extern "C" */
+#endif
+#endif

--- a/src/overlaybd/fs/zfile/test/test.cpp
+++ b/src/overlaybd/fs/zfile/test/test.cpp
@@ -256,8 +256,25 @@ TEST_F(ZFileTest, checksum)
     }
 }
 
+TEST_F(ZFileTest, dsa) {
+    const int buf_size = 4194304; // 4M
+    const int crc_count = 3000;
+    int ret = 0;
 
 
+    for(auto i = 0; i < crc_count; i++){
+        void* buf = malloc(buf_size);
+        DEFER(free(buf));
+        uint32_t checksum_dsa = FileSystem::crc32::crc32c(buf, buf_size);
+        uint32_t checksum_sse = FileSystem::crc32::testing::crc32c_fast(buf, buf_size, 0);
+
+        if(checksum_dsa != checksum_sse){
+            ret = 1;
+        }
+    }
+
+    ASSERT_EQ(ret, 0);
+}
 
 int main(int argc, char **argv)
 {


### PR DESCRIPTION
Intel® DSA is a high-performance data copy and transformation accelerator that will be integrated into future Intel® processors, targeted for optimizing streaming data movement and transformation operations common with applications for high-performance storage, networking, persistent memory, and various data processing applications.

Intel® DSA replaces the Intel® QuickData Technology, which is a part of Intel® I/O Acceleration Technology.

The goal is to provide higher overall system performance for data mover and transformation operations while freeing up CPU cycles for higher-level functions. Intel® DSA enables high-performance data mover capability to/from volatile memory, persistent memory, memory-mapped I/O, and through a Non-Transparent Bridge (NTB) device to/from remote volatile and persistent memory on another node in a cluster. Enumeration and configuration are done with a PCI Express* compatible programming interface to the Operating System (OS) and can be controlled through a device driver.

Besides the basic data mover operations, Intel® DSA supports a set of transformation operations on memory. For example:

Generate and test CRC checksum, or Data Integrity Field (DIF) to support storage and networking applications.
Memory Compare and delta generate/merge to support VM migration, VM Fast check-pointing, and software-managed memory deduplication usages.

We did a performance comparison test, and the QPS calculated by CRC were 960124 and 7977434 respectively in the case of 4K size without and with DSA. About a nine-times improvement using DSA in performance.