### PR TITLE
Support sparse file as overlayBD writable layer

### DIFF
--- a/src/overlaybd/fs/lsmt/file.h
+++ b/src/overlaybd/fs/lsmt/file.h
@@ -97,6 +97,7 @@ struct LayerInfo {
     UUID parent_uuid;
     UUID uuid;
     char *user_tag = nullptr; // a user provided string of message, 256B at most
+    bool sparse_rw = false;
     size_t len = 0;           // len of user_tag; if it's 0, it will be detected with strlen()
     LayerInfo(IFile *_fdata = nullptr, IFile *_findex = nullptr) : fdata(_fdata), findex(_findex) {
         parent_uuid.clear();

--- a/src/overlaybd/fs/lsmt/test/CMakeLists.txt
+++ b/src/overlaybd/fs/lsmt/test/CMakeLists.txt
@@ -4,9 +4,11 @@ link_directories($ENV{GFLAGS}/lib)
 include_directories($ENV{GTEST}/googletest/include)
 link_directories($ENV{GTEST}/lib)
 
+
+
 add_executable(lsmt_test test.cpp)
 target_link_libraries(lsmt_test gtest gtest_main gflags pthread fs_lib base_lib photon_lib
-    -laio -lrt)
+  -laio -lrt )
 
 add_test(
   NAME lsmt_test


### PR DESCRIPTION
Overlaybd supports writable layer by append-only mode. Continuous
data writing will generate a lot of garbage, making the disk usage
uncontrollable.

In this commit, we use Linux sparse file as another writable layer
mode to control disk usage precisely.

Signed-off-by: Yifan Yuan <tuji.yyf@alibaba-inc.com>