### PR TITLE
ZFile support batch decompress

### DIFF
--- a/src/overlaybd/zfile/compressor.h
+++ b/src/overlaybd/zfile/compressor.h
@@ -89,6 +89,10 @@ public:
     */
     virtual int decompress(const unsigned char *src, size_t src_len, unsigned char *dst,
                            size_t dst_len) = 0;
+
+    virtual int decompress_batch(const unsigned char *src, size_t *src_chunk_len, unsigned char *dst,
+                        size_t dst_buffer_capacity, size_t *dst_chunk_len /* save result chunk length */, 
+                        size_t nchunk) = 0;
 };
 
 extern "C" ICompressor *create_compressor(const CompressArgs *args);

--- a/src/overlaybd/zfile/lz4/lz4-qat.c
+++ b/src/overlaybd/zfile/lz4/lz4-qat.c
@@ -33,9 +33,14 @@ LZ4LIB_API int LZ4_compress_qat(LZ4_qat_param *pQat, const unsigned char *const 
     return status;
 }
 
-LZ4LIB_API int LZ4_decompress_qat(LZ4_qat_param *pQat, const char *source, char *dest,
-                                  int compressedSize, int maxDecompressedSize) {
+LZ4LIB_API int LZ4_decompress_qat(LZ4_qat_param *pQat, const unsigned char *const raw_data[],
+                                size_t src_chunk_len[], unsigned char *decompressed_data[],
+                                size_t dst_chunk_len[], size_t n){
     int32_t status = 0;
-
+    for (ssize_t i = 0; i < n; i++) {
+        int ret = LZ4_decompress_safe((const char *)raw_data[i], (char *)decompressed_data[i],
+                                        src_chunk_len[i], 4096);
+        dst_chunk_len[i] = ret;
+    }
     return status;
 }

--- a/src/overlaybd/zfile/lz4/lz4-qat.h
+++ b/src/overlaybd/zfile/lz4/lz4-qat.h
@@ -94,8 +94,10 @@ LZ4LIB_API int LZ4_compress_qat(LZ4_qat_param *pQat, const unsigned char *const 
    (negative value). If the source stream is detected malformed, the function will stop decoding and
    return a negative result. This function is protected against malicious data packets.
 */
-LZ4LIB_API int LZ4_decompress_qat(LZ4_qat_param *pQat, const char *src, char *dst,
-                                  int compressedSize, int dstCapacity);
+LZ4LIB_API int LZ4_decompress_qat(LZ4_qat_param *pQat, const unsigned char *const raw_data[],
+                                size_t src_chunk_len[], unsigned char *decompressed_data[],
+                                size_t dst_chunk_len[], size_t n);
+
 
 int qat_init(LZ4_qat_param *pQat);
 


### PR DESCRIPTION
1.Add ICompressor::batch_decompress() to support QAT
2.ZFile will use batch decompress by default.

Accelerate compression to provide improved efficiency, scalability and
performance. Intel QuickAssist Technology (Intel QAT) offloading
Compression from CPU which can save cycles, time and space.

As the complexity of applications continues to grow, systems need more
and more computational resources for workloads, including cryptography
and data compression.

The drivers and patches offered here assist application developers to
take advantage of Intel® QuickAssist Integrated Accelerator that is
offered with platforms based on Intel® processors.

To Learn how to use Intel® QuickAssist Technology and run example code,
review our tutorial videos on Intel Developer Zone – Intel® QuickAssist
Technology Technical Getting Started Tutorials -
https://software.intel.com/en-us/networking/quickassist

Signed-off-by: Siwei Qin <siwei.qin@intel.com>
Co-Authored-By: Haibin Huang <haibin.huang@intel.com>
Co-Authored-By: Siwei Qin <siwei.qin@intel.com>