### PR TITLE
support `zstd` in ZFile compression

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -22,7 +22,7 @@ jobs:
       shell: bash
       run: |
         sudo apt update -y
-        sudo apt install -y libgflags-dev libcurl4-openssl-dev libssl-dev libaio-dev libnl-3-dev libnl-genl-3-dev
+        sudo apt install -y libgflags-dev libcurl4-openssl-dev libssl-dev libaio-dev libnl-3-dev libnl-genl-3-dev libzstd-dev
         sudo apt install -y uuid-dev libjson-c-dev libkmod-dev libsystemd-dev autoconf automake libtool libpci-dev nasm
         wget https://github.com/google/googletest/archive/refs/tags/release-1.10.0.tar.gz
         tar -zxvf release-1.10.0.tar.gz

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,6 +17,8 @@ set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fpic")
 
 set(CMAKE_CXX_STANDARD_LIBRARIES "-static-libgcc ${CMAKE_CXX_STANDARD_LIBRARIES}")
 find_library(STATIC_LIBSTDC++ libstdc++.a PATHS /usr/lib/gcc/*/*)
+find_library(STATIC_LIBZSTD libzstd.a PATHS /usr/lib/x86_64-linux-gnu/* /usr/lib64/*)
+
 if(NOT ${STATIC_LIBSTDC++} STREQUAL "STATIC_LIBSTDC++-NOTFOUND")
   set(CMAKE_CXX_STANDARD_LIBRARIES "-static-libstdc++ ${CMAKE_CXX_STANDARD_LIBRARIES}")
 endif()

--- a/README.md
+++ b/README.md
@@ -52,8 +52,8 @@ To build overlaybd from source code, the following dependencies are required:
 * gcc/g++ >= 7
 
 * Libaio, libcurl, libnl3, glib2 and openssl runtime and development libraries.
-  * CentOS/Fedora: `sudo yum install libaio-devel libcurl-devel openssl-devel libnl3-devel`
-  * Debian/Ubuntu: `sudo apt install libcurl4-openssl-dev libssl-dev libaio-dev libnl-3-dev libnl-genl-3-dev libgflags-dev`
+  * CentOS/Fedora: `sudo yum install libaio-devel libcurl-devel openssl-devel libnl3-devel libzstd-static`
+  * Debian/Ubuntu: `sudo apt install libcurl4-openssl-dev libssl-dev libaio-dev libnl-3-dev libnl-genl-3-dev libgflags-dev libzstd-dev`
 
 #### Build
 

--- a/src/image_service.cpp
+++ b/src/image_service.cpp
@@ -159,7 +159,7 @@ int load_cred_from_http(const std::string addr /* http server */, const std::str
     }
     LOG_INFO("traceId: `, succ: `", response.traceId(), response.success());
     if (response.success() == false) {
-        LOG_ERRNO_RETURN(0, -1, "http request failed.") 
+        LOG_ERRNO_RETURN(0, -1, "http request failed.");
     }
     ImageConfigNS::AuthConfig cfg;
     return parse_auths(response.data().auths(), remote_path, username, password);

--- a/src/overlaybd/zfile/CMakeLists.txt
+++ b/src/overlaybd/zfile/CMakeLists.txt
@@ -37,8 +37,8 @@ if(ENABLE_DSA OR ENABLE_ISAL)
 endif()
 set (CMAKE_CXX_STANDARD 14)
 
-add_library(zfile_lib STATIC  ${SOURCE_ZFILE} ${SOURCE_LZ4})
-target_link_libraries(zfile_lib photon_static crc32_lib)
+add_library(zfile_lib STATIC ${SOURCE_ZFILE} ${SOURCE_LZ4})
+target_link_libraries(zfile_lib photon_static crc32_lib ${STATIC_LIBZSTD})
 
 if (ENABLE_QAT)
     target_compile_definitions(zfile_lib PUBLIC -DENABLE_QAT)

--- a/src/overlaybd/zfile/compressor.cpp
+++ b/src/overlaybd/zfile/compressor.cpp
@@ -16,9 +16,14 @@
 
 #include "compressor.h"
 #include "lz4/lz4.h"
+#include <cstddef>
 #include <photon/common/alog.h>
 #include <memory>
 #include <vector>
+#include <zstd.h>
+#include <sys/fcntl.h>
+#include "photon/fs/filesystem.h"
+
 #ifdef ENABLE_QAT
 #include "lz4/lz4-qat.h"
 extern "C" {
@@ -33,22 +38,108 @@ namespace ZFile {
 #define QAT_VENDOR_ID 0x8086
 #define QAT_DEVICE_ID 0x4940
 
-class Compressor_lz4 : public ICompressor {
+class BaseCompressor : public ICompressor {
 public:
     uint32_t max_dst_size = 0;
     uint32_t src_blk_size = 0;
+    // vector<unsigned char *> raw_data;
+    vector<unsigned char *> compressed_data;
+    vector<unsigned char *> uncompressed_data;
+
+    const int DEFAULT_N_BATCH = 256;
+
+    virtual int init(const CompressArgs *args) {
+        auto opt = &args->opt;
+        if (opt == nullptr) {
+            LOG_ERROR_RETURN(EINVAL, -1, "CompressOptions* is nullptr.");
+        }
+
+        src_blk_size = opt->block_size;
+        LOG_INFO("create batch buffer, size: `", nbatch());
+        // raw_data.resize(nbatch());
+        compressed_data.resize(nbatch());
+        uncompressed_data.resize(nbatch());
+        return 0;
+    }
+
+    virtual int nbatch() override {
+        return 1;
+    }
+
+    virtual int do_compress(size_t *src_chunk_len /* uncompressed length per block */,
+                            size_t *dst_chunk_len, size_t dst_buffer_capacity, size_t nblock) = 0;
+
+    virtual int do_decompress(size_t *src_chunk_len,
+                              /* compressed length per block */ size_t *dst_chunk_len,
+                              size_t dst_buffer_capacity, size_t nblock) = 0;
+
+    virtual int compress(const unsigned char *src, size_t src_len, unsigned char *dst,
+                         size_t dst_len) override {
+
+        size_t dst_chunk_len;
+        if (compress_batch(src, &src_len, dst, dst_len, &dst_chunk_len, 1) != 0) {
+            LOG_ERRNO_RETURN(0, -1, "compress data failed.");
+        }
+        return dst_chunk_len; // return decompressed size for single block.
+    }
+
+    int compress_batch(const unsigned char *src, size_t *src_chunk_len, unsigned char *dst,
+                       size_t dst_buffer_capacity, size_t *dst_chunk_len, size_t n) override {
+
+        if (dst_buffer_capacity / n < max_dst_size) {
+            LOG_ERROR_RETURN(ENOBUFS, -1, "dst_len should be greater than `", max_dst_size - 1);
+        }
+        off_t src_offset = 0, dst_offset = 0;
+        int ret = 0;
+        for (ssize_t i = 0; i < n; i++) {
+            uncompressed_data[i] = ((unsigned char *)src + src_offset);
+            compressed_data[i] = ((unsigned char *)dst + dst_offset);
+            src_offset += src_chunk_len[i];
+            dst_offset += dst_buffer_capacity / n;
+        }
+        return do_compress(src_chunk_len, dst_chunk_len, dst_buffer_capacity, n);
+    }
+
+    virtual int decompress(const unsigned char *src, size_t src_len, unsigned char *dst,
+                           size_t dst_len) override {
+
+        size_t dst_chunk_len;
+        if (decompress_batch(src, &src_len, dst, dst_len, &dst_chunk_len, 1) != 0) {
+            LOG_ERRNO_RETURN(0, -1, "compress data failed.");
+        }
+        return dst_chunk_len; // return decompressed size for single block.
+    }
+
+    int decompress_batch(const unsigned char *src, size_t *src_chunk_len, unsigned char *dst,
+                         size_t dst_buffer_capacity, size_t *dst_chunk_len, size_t n) override {
+
+        if (dst_buffer_capacity / n < src_blk_size) {
+            LOG_ERROR_RETURN(ENOBUFS, -1,
+                             "dst_len (`) should be greater than compressed block size `",
+                             dst_buffer_capacity / n, src_blk_size);
+        }
+        off_t src_offset = 0, dst_offset = 0;
+        int ret = 0;
+        for (ssize_t i = 0; i < n; i++) {
+            compressed_data[i] = ((unsigned char *)src + src_offset);
+            uncompressed_data[i] = ((unsigned char *)dst + dst_offset);
+            src_offset += src_chunk_len[i];
+            dst_offset += dst_buffer_capacity / n;
+        }
+
+        return do_decompress(src_chunk_len, dst_chunk_len, dst_buffer_capacity, n);
+    }
+};
+
+class LZ4Compressor : public BaseCompressor {
+public:
     bool qat_enable = false;
 #ifdef ENABLE_QAT
     LZ4_qat_param *pQat = nullptr;
 #endif
-    vector<unsigned char *> raw_data;
-    vector<unsigned char *> compressed_data;
-    vector<unsigned char *> decompressed_data;
 
-    const int DEFAULT_N_BATCH = 256;
-
-    ~Compressor_lz4() {
-#ifdef ENABLE_QAT  
+    ~LZ4Compressor() {
+#ifdef ENABLE_QAT
         if (pQat) {
             qat_uninit(pQat);
             delete pQat;
@@ -77,16 +168,16 @@ public:
         return false;
     }
 
-    int init(const CompressArgs *args) {
-        auto opt = &args->opt;
-        if (opt == nullptr) {
-            LOG_ERROR_RETURN(EINVAL, -1, "CompressOptions* is nullptr.");
+    virtual int init(const CompressArgs *args) override {
+
+        if (BaseCompressor::init(args) != 0) {
+            LOG_ERROR_RETURN(EINVAL, -1, "BaseCompressor init failed");
         }
+        auto opt = &args->opt;
         if (opt->type != CompressOptions::LZ4) {
             LOG_ERROR_RETURN(EINVAL, -1,
                              "Compression type invalid. (expected: CompressionOptions::LZ4)");
         }
-        src_blk_size = opt->block_size;
         max_dst_size = LZ4_compressBound(src_blk_size);
 #ifdef ENABLE_QAT
         if (check_qat()) {
@@ -95,21 +186,7 @@ public:
             qat_enable = true;
         }
 #endif
-        LOG_INFO("create batch buffer, size: `", nbatch());
-        raw_data.resize(nbatch());
-        compressed_data.resize(nbatch());
-        decompressed_data.resize(nbatch());
         return 0;
-    }
-
-    int compress(const unsigned char *src, size_t src_len, unsigned char *dst,
-                 size_t dst_len) override {
-
-        size_t dst_chunk_len;
-        if (compress_batch(src, &src_len, dst, dst_len, &dst_chunk_len, 1) != 0) {
-            LOG_ERRNO_RETURN(0, -1, "compress data failed.");
-        }
-        return dst_chunk_len; // return decompressed size for single block.
     }
 
     int nbatch() override {
@@ -117,74 +194,46 @@ public:
         return (qat_enable ? DEFAULT_N_BATCH : 1);
     }
 
-    int compress_batch(const unsigned char *src, size_t *src_chunk_len, unsigned char *dst,
-                       size_t dst_buffer_capacity, size_t *dst_chunk_len, size_t n) override {
+    virtual int do_compress(size_t *src_chunk_len, size_t *dst_chunk_len,
+                            size_t dst_buffer_capacity, size_t nblock) override {
 
-        if (dst_buffer_capacity / n < max_dst_size) {
-            LOG_ERROR_RETURN(ENOBUFS, -1, "dst_len should be greater than `", max_dst_size - 1);
-        }
-        off_t src_offset = 0, dst_offset = 0;
         int ret = 0;
-        for (ssize_t i = 0; i < n; i++) {
-            raw_data[i] = ((unsigned char *)src + src_offset);
-            compressed_data[i] = ((unsigned char *)dst + dst_offset);
-            src_offset += src_chunk_len[i];
-            dst_offset += dst_buffer_capacity / n;
-        }
 #ifdef ENABLE_QAT
         if (qat_enable) {
-            ret = LZ4_compress_qat(pQat, &raw_data[0], src_chunk_len, &compressed_data[0], dst_chunk_len, n);
+            ret = LZ4_compress_qat(pQat, &raw_data[0], src_chunk_len, &compressed_data[0],
+                                   dst_chunk_len, n);
             if (ret < 0) {
                 LOG_ERROR_RETURN(EFAULT, -1, "LZ4 compress data failed. (retcode: `).", ret);
             }
             return ret;
         }
 #endif
-        for (ssize_t i = 0; i < n; i++) {
-            ret = LZ4_compress_default((const char *)raw_data[i], (char *)compressed_data[i],
-                                       src_chunk_len[i], dst_buffer_capacity / n);
-           
+        for (ssize_t i = 0; i < nblock; i++) {
+            ret =
+                LZ4_compress_default((const char *)uncompressed_data[i], (char *)compressed_data[i],
+                                     src_chunk_len[i], dst_buffer_capacity / nblock);
+
             dst_chunk_len[i] = ret;
             if (ret < 0) {
                 LOG_ERROR_RETURN(EFAULT, -1, "LZ4 compress data failed. (retcode: `).", ret);
             }
             if (ret == 0) {
-                LOG_ERROR_RETURN(EFAULT, -1,
+                LOG_ERROR_RETURN(
+                    EFAULT, -1,
                     "Compression worked, but was stopped because the *dst couldn't hold all the information.");
             }
         }
         return 0;
     }
 
-    int decompress(const unsigned char *src, size_t src_len, unsigned char *dst,
-                   size_t dst_len) override {
+    int do_decompress(size_t *src_chunk_len, size_t *dst_chunk_len, size_t dst_buffer_capacity,
+                      size_t n) override {
 
-        size_t dst_chunk_len;
-        if (decompress_batch(src, &src_len, dst, dst_len, &dst_chunk_len, 1) != 0) {
-            LOG_ERRNO_RETURN(0, -1, "compress data failed.");
-        }
-        return dst_chunk_len; // return decompressed size for single block.
-    }
-
-    int decompress_batch(const unsigned char *src, size_t *src_chunk_len, unsigned char *dst,
-                         size_t dst_buffer_capacity, size_t *dst_chunk_len, size_t n) override {
-
-        if (dst_buffer_capacity / n < src_blk_size) {
-            LOG_ERROR_RETURN(ENOBUFS, -1, "dst_len (`) should be greater than compressed block size `",
-                             dst_buffer_capacity / n, src_blk_size);
-        }
-        off_t src_offset = 0, dst_offset = 0;
         int ret = 0;
-        for (ssize_t i = 0; i < n; i++) {
-            raw_data[i] = ((unsigned char *)src + src_offset);
-            decompressed_data[i] = ((unsigned char *)dst + dst_offset);
-            src_offset += src_chunk_len[i];
-            dst_offset += dst_buffer_capacity / n;
-        }
 #ifdef ENABLE_QAT
         if (qat_enable) {
-            ret = LZ4_decompress_qat(pQat, &raw_data[0], src_chunk_len, &decompressed_data[0],
-                                   dst_chunk_len, n);
+            ret = LZ4_decompress_qat(pQat, &compressed_data[0], src_chunk_len,
+                                     &uncompressed_data[0], dst_chunk_len, n);
             if (ret < 0) {
                 LOG_ERROR_RETURN(EFAULT, -1, "LZ4 decompress data failed. (retcode: `).", ret);
             }
@@ -192,18 +241,105 @@ public:
         }
 #endif
         for (ssize_t i = 0; i < n; i++) {
-            ret = LZ4_decompress_safe((const char *)raw_data[i], (char *)decompressed_data[i],
-                                       src_chunk_len[i], dst_buffer_capacity / n);
+            ret =
+                LZ4_decompress_safe((const char *)compressed_data[i], (char *)uncompressed_data[i],
+                                    src_chunk_len[i], dst_buffer_capacity / n);
 
             dst_chunk_len[i] = ret;
             if (ret < 0) {
                 LOG_ERROR_RETURN(EFAULT, -1, "LZ4 decompress data failed. (retcode: `).", ret);
             }
             if (ret == 0) {
-                LOG_ERROR_RETURN(EFAULT, -1, "LZ4 decompress returns 0. THIS SHOULD BE NEVER HAPPEN!");
+                LOG_ERROR_RETURN(EFAULT, -1,
+                                 "LZ4 decompress returns 0. THIS SHOULD BE NEVER HAPPEN!");
             }
         }
         return 0;
+    }
+};
+
+class Compressor_zstd : public BaseCompressor {
+public:
+    static const int cLevel = 3;
+
+    ~Compressor_zstd() {
+    }
+
+    virtual int init(const CompressArgs *args) override {
+        if (BaseCompressor::init(args) != 0) {
+            LOG_ERROR_RETURN(EINVAL, -1, "BaseCompressor init failed");
+        }
+        const CompressOptions *opt = &args->opt;
+        if (opt->type != CompressOptions::ZSTD) {
+            LOG_ERROR_RETURN(EINVAL, -1,
+                             "Compression type invalid.(expected: CompressionOptions::ZSTD)");
+        }
+        max_dst_size = ZSTD_compressBound(src_blk_size);
+        return 0;
+    }
+
+    virtual int compress(const unsigned char *src, size_t src_len, unsigned char *dst,
+                         size_t dst_len) override {
+        if (dst_len < max_dst_size) {
+            LOG_ERROR_RETURN(ENOBUFS, -1, "dst_len should be greater than `", max_dst_size - 1);
+        }
+        size_t cSize = ZSTD_compress(dst, dst_len, src, src_len, cLevel);
+        if (ZSTD_isError(cSize)) {
+            LOG_ERROR_RETURN(0, -1, "compress error: `", ZSTD_getErrorName(cSize));
+        }
+        return cSize;
+    }
+
+    virtual int do_compress(size_t *src_chunk_len /* uncompressed length per block */,
+                            size_t *dst_chunk_len, size_t dst_buffer_capacity,
+                            size_t nblock) override {
+
+        int ret = 0;
+        for (int i = 0; i < nblock; i++) {
+            ret = compress(uncompressed_data[i], src_chunk_len[i], compressed_data[i],
+                           dst_buffer_capacity / nblock);
+            if (ret < 0) {
+                LOG_ERROR_RETURN(EFAULT, -1, "ZSTD compress data failed. (retcode: `).", ret);
+            }
+            dst_chunk_len[i] = ret;
+        }
+        return 0;
+    }
+
+    virtual int do_decompress(size_t *src_chunk_len,
+                              /* compressed length per block */ size_t *dst_chunk_len,
+                              size_t dst_buffer_capacity, size_t nblock) override {
+
+        int ret = 0;
+        for (ssize_t i = 0; i < nblock; i++) {
+            ret = decompress((const unsigned char *)uncompressed_data[i], src_chunk_len[i],
+                             compressed_data[i], dst_buffer_capacity / nblock);
+
+            dst_chunk_len[i] = ret;
+            if (ret < 0) {
+                LOG_ERROR_RETURN(EFAULT, -1, "LZ4 compress data failed. (retcode: `).", ret);
+            }
+            if (ret == 0) {
+                LOG_ERROR_RETURN(
+                    EFAULT, -1,
+                    "Compression worked, but was stopped because the *dst couldn't hold all the information.");
+            }
+        }
+        return 0;
+    }
+
+    virtual int decompress(const unsigned char *src, size_t src_len, unsigned char *dst,
+                           size_t dst_len) override {
+        if (dst_len < src_blk_size) {
+            LOG_ERROR_RETURN(0, -1, "dst_len (`) should be greater than compressed block size `",
+                             dst_len, src_blk_size);
+        }
+
+        size_t ret = ZSTD_decompress(dst, dst_len, src, src_len);
+        if (ZSTD_isError(ret)) {
+            LOG_ERROR_RETURN(0, -1, "decompress error: `", ZSTD_getErrorName(ret));
+        }
+        return ret;
     }
 };
 
@@ -214,9 +350,17 @@ ICompressor *create_compressor(const CompressArgs *args) {
     switch (opt.type) {
 
     case CompressOptions::LZ4:
-        rst = new Compressor_lz4;
+        rst = new LZ4Compressor;
+        LOG_INFO("ZFileObject using LZ4 algorithm");
         if (rst != nullptr) {
-            init_flg = ((Compressor_lz4 *)rst)->init(args);
+            init_flg = ((LZ4Compressor *)rst)->init(args);
+        }
+        break;
+    case CompressOptions::ZSTD:
+        rst = new Compressor_zstd;
+        LOG_INFO("ZFileObject using ZSTD algorithm");
+        if (rst != nullptr) {
+            init_flg = ((Compressor_zstd *)rst)->init(args);
         }
         break;
     default:

--- a/src/overlaybd/zfile/zfile.cpp
+++ b/src/overlaybd/zfile/zfile.cpp
@@ -444,12 +444,8 @@ public:
                 memcpy(buf, raw + block.cp_begin, block.cp_len);
             }
             readn += block.cp_len;
-            // LOG_DEBUG("append buf, {offset: `, length: `, crc: `}", (off_t)buf -
-            // (off_t)start_addr,
-            //           block.cp_len, block.crc32_code());
             buf = (unsigned char *)buf + block.cp_len;
         }
-        // LOG_DEBUG("done. (readn: `)", readn);
         return readn;
     }
 };

--- a/src/overlaybd/zfile/zfile.cpp
+++ b/src/overlaybd/zfile/zfile.cpp
@@ -144,60 +144,57 @@ public:
         uint64_t index_offset; // in bytes
         uint64_t index_size;   // # of SegmentMappings
         uint64_t raw_data_size;
-        uint64_t reserved_0; // fix compatibility with HeaderTrailer in release_v1.0
+        uint64_t reserved_0;
         CompressOptions opt;
 
     } /* __attribute__((packed)) */;
 
     struct JumpTable {
-        typedef uint16_t inttype;
-        static const inttype inttype_max = UINT16_MAX;
-        static const int DEFAULT_PART_SIZE = 16; // 16 x 4k = 64k
-        static const int DEFAULT_LSHIFT = 16;    // save local minimum of each part.
+        typedef uint16_t uinttype;
+        static const uinttype uinttype_max = UINT16_MAX;
+        int group_size;
 
-        std::vector<uint64_t> partial_offset; // 48 bits logical offset + 16 bits partial minimum
-        std::vector<inttype> deltas;
+        std::vector<uint64_t> partial_offset;
+        std::vector<uinttype> deltas; // partial sum in each page;
 
         off_t operator[](size_t idx) const {
-            // return BASE  + idx % (page_size) * local_minimum + sum(delta - local_minimum)
-            off_t part_idx = idx / DEFAULT_PART_SIZE;
-            off_t inner_idx = idx & (DEFAULT_PART_SIZE - 1);
-            auto local_min = partial_offset[part_idx] & ((1 << DEFAULT_LSHIFT) - 1);
-            auto part_offset = partial_offset[part_idx] >> DEFAULT_LSHIFT;
-            off_t ret = part_offset + deltas[idx] + (inner_idx)*local_min;
-            return ret;
+            // return BASE  + deltas[ idx % (page_size) ]
+            off_t part_idx = idx / group_size;
+            off_t inner_idx = idx & (group_size - 1);
+            auto part_offset = partial_offset[part_idx];
+            if (inner_idx) {
+                return part_offset + deltas[idx];
+            }
+            return part_offset;
         }
 
         size_t size() const {
             return deltas.size();
         }
 
-        int build(const uint32_t *ibuf, size_t n, off_t offset_begin) {
-            int part_size = DEFAULT_PART_SIZE;
-            partial_offset.reserve(n / part_size + 1);
+        int build(const uint32_t *ibuf, size_t n, off_t offset_begin, uint32_t block_size) {
+            group_size = (uinttype_max + 1) / block_size;
+            partial_offset.reserve(n / group_size + 1);
             deltas.reserve(n + 1);
-            inttype local_min = 0;
             auto raw_offset = offset_begin;
-            auto lshift = DEFAULT_LSHIFT;
-            partial_offset.push_back((raw_offset << lshift) + local_min);
+            partial_offset.push_back(raw_offset);
             deltas.push_back(0);
             for (ssize_t i = 1; i < (ssize_t)n + 1; i++) {
                 raw_offset += ibuf[i - 1];
-                if ((i % part_size) == 0) {
-                    local_min = inttype_max;
-                    for (ssize_t j = i; j < std::min((ssize_t)n + 1, i + part_size); j++)
-                        local_min = std::min((inttype)ibuf[j - 1], local_min);
-                    partial_offset.push_back((uint64_t(raw_offset) << lshift) + local_min);
+                if ((i % group_size) == 0) {
+                    partial_offset.push_back(raw_offset);
                     deltas.push_back(0);
                     continue;
                 }
-                deltas.push_back(deltas[i - 1] + ibuf[i - 1] - local_min);
-                // LOG_DEBUG("idx `: `", i, this->operator[](i));
+                assert((uint64_t)deltas[i - 1] + ibuf[i - 1] < (uint64_t)uinttype_max);
+                deltas.push_back(deltas[i - 1] + ibuf[i - 1]);
+                LOG_DEBUG("deltas[`]: `, ibuf[`]: `, raw_offset: `", i, deltas[i], i, ibuf[i - 1],
+                          this->operator[](i));
             }
-            LOG_DEBUG("create jump table done. {part_count: `, deltas_count: `, size: `}",
-                      partial_offset.size(), deltas.size(),
-                      deltas.size() * sizeof(deltas[0]) +
-                          partial_offset.size() * sizeof(partial_offset[0]));
+            LOG_INFO("create jump table done. {part_count: `, deltas_count: `, size: `}",
+                     partial_offset.size(), deltas.size(),
+                     deltas.size() * sizeof(deltas[0]) +
+                         partial_offset.size() * sizeof(partial_offset[0]));
             return 0;
         }
 
@@ -247,8 +244,6 @@ public:
             m_idx = m_begin_idx;
             m_end = m_offset + count - 1;
             m_end_idx = (m_offset + count - 1) / m_block_size + 1;
-            // LOG_DEBUG("[ offset: `, length: ` ], begin_blk: `, end_blk: `, enable_verify: `",
-            //           offset, count, m_begin_idx, m_end_idx, m_verify);
         }
 
         int reload(size_t idx) {
@@ -269,8 +264,6 @@ public:
         int read_blocks(size_t begin, size_t end) {
             auto read_size = std::min(MAX_READ_SIZE, get_blocks_length(begin, end));
             auto begin_offset = m_zfile->m_jump_table[begin];
-            // LOG_DEBUG("block idx: [`, `), start_offset: `, read_size: `", begin, end, begin_offset,
-            //           read_size);
             auto readn = m_zfile->m_file->pread(m_buf, read_size, begin_offset);
             if (readn != (ssize_t)read_size) {
                 LOG_ERRNO_RETURN(0, -1, "read compressed blocks failed. (offset: `, len: `)",
@@ -309,7 +302,6 @@ public:
                 LOG_WARN("crc32 not support.");
                 return -1;
             }
-            // LOG_DEBUG("{crc32_offset: `}", compressed_size());
             return *(uint32_t *)&(m_buf[m_buf_offset + compressed_size()]);
         }
 
@@ -352,8 +344,6 @@ public:
                     cp_len = m_reader->get_inblock_offset(m_reader->m_end) + 1;
                 }
                 cp_len -= cp_begin;
-                // LOG_DEBUG("block id: ` cp_begin: `, cp_len: `, compressed_size: `", blk_idx,
-                //           cp_begin, cp_len, compressed_size);
             }
 
             iterator &operator++() {
@@ -454,7 +444,8 @@ public:
                 memcpy(buf, raw + block.cp_begin, block.cp_len);
             }
             readn += block.cp_len;
-            // LOG_DEBUG("append buf, {offset: `, length: `, crc: `}", (off_t)buf - (off_t)start_addr,
+            // LOG_DEBUG("append buf, {offset: `, length: `, crc: `}", (off_t)buf -
+            // (off_t)start_addr,
             //           block.cp_len, block.crc32_code());
             buf = (unsigned char *)buf + block.cp_len;
         }
@@ -678,7 +669,8 @@ bool load_jump_table(IFile *file, CompressionFile::HeaderTrailer *pheader_traile
     LOG_DEBUG("index_offset: `", pht->index_offset);
     ret = file->pread((void *)(ibuf.get()), index_bytes, pht->index_offset);
     jump_table.build(ibuf.get(), pht->index_size,
-                     CompressionFile::HeaderTrailer::SPACE + pht->opt.dict_size);
+                     CompressionFile::HeaderTrailer::SPACE + pht->opt.dict_size,
+                     pht->opt.block_size);
     if (pheader_trailer)
         *pheader_trailer = *pht;
     return true;
@@ -780,9 +772,9 @@ int zfile_compress(IFile *file, IFile *as, const CompressArgs *args) {
     int nbatch = compressor->nbatch();
     LOG_DEBUG("nbatch: `, buffer need allocate: `", nbatch, nbatch * buf_size);
     auto raw_data = new unsigned char[nbatch * buf_size];
-    DEFER(delete [] raw_data);
+    DEFER(delete[] raw_data);
     auto compressed_data = new unsigned char[nbatch * buf_size];
-    DEFER(delete [] compressed_data);
+    DEFER(delete[] compressed_data);
     std::vector<size_t> raw_chunk_len, compressed_len;
     compressed_len.resize(nbatch);
     raw_chunk_len.resize(nbatch);
@@ -804,9 +796,10 @@ int zfile_compress(IFile *file, IFile *as, const CompressArgs *args) {
             raw_chunk_len[n++] = block_size;
             step -= block_size;
         }
-        ret = compressor->compress_batch(raw_data, &(raw_chunk_len[0]), compressed_data, n * buf_size,
-            &(compressed_len[0]), n);
-        if (ret != 0) return -1;
+        ret = compressor->compress_batch(raw_data, &(raw_chunk_len[0]), compressed_data,
+                                         n * buf_size, &(compressed_len[0]), n);
+        if (ret != 0)
+            return -1;
         for (off_t j = 0; j < n; j++) {
             ret = as->write(&compressed_data[j * buf_size], compressed_len[j]);
             if (ret < (ssize_t)compressed_len[j]) {
@@ -815,12 +808,12 @@ int zfile_compress(IFile *file, IFile *as, const CompressArgs *args) {
             if (crc32_verify) {
                 auto crc32_code = crc32c(&compressed_data[j * buf_size], compressed_len[j]);
                 LOG_DEBUG("append ` bytes crc32_code: {offset: `, count: `, crc32: `}",
-                            sizeof(uint32_t), moffset, compressed_len[j], crc32_code);
+                          sizeof(uint32_t), moffset, compressed_len[j], crc32_code);
                 compressed_len[j] += sizeof(uint32_t);
                 ret = as->write(&crc32_code, sizeof(uint32_t));
                 if (ret < sizeof(uint32_t)) {
                     LOG_ERRNO_RETURN(0, -1, "failed to write crc32code, offset: `, crc32: `",
-                        moffset, crc32_code);
+                                     moffset, crc32_code);
                 }
             }
             block_len.push_back(compressed_len[j]);


### PR DESCRIPTION
#125 

  - add ZSTDCompressor
  - refactoring ZFile
  - in cli-tool `overlaybd-zfile`, add `--algorithm` and `--bs` option

Signed-off-by: Yifan Yuan <tuji.yyf@alibaba-inc.com>