### PR TITLE
Update Googletest to v1.11.0

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -24,9 +24,9 @@ jobs:
         sudo apt update -y
         sudo apt install -y libgflags-dev libcurl4-openssl-dev libssl-dev libaio-dev libnl-3-dev libnl-genl-3-dev libzstd-dev
         sudo apt install -y uuid-dev libjson-c-dev libkmod-dev libsystemd-dev autoconf automake libtool libpci-dev nasm
-        wget https://github.com/google/googletest/archive/refs/tags/release-1.10.0.tar.gz
-        tar -zxvf release-1.10.0.tar.gz
-        cd googletest-release-1.10.0/
+        wget https://github.com/google/googletest/archive/refs/tags/release-1.11.0.tar.gz
+        tar -zxvf release-1.11.0.tar.gz
+        cd googletest-release-1.11.0/
         cmake CMakeLists.txt
         make
         sudo make install


### PR DESCRIPTION
Fixes error in #131

```
In file included from /home/runner/work/overlaybd/overlaybd/googletest-release-1.10.0/googletest/src/gtest-all.cc:42:
/home/runner/work/overlaybd/overlaybd/googletest-release-1.10.0/googletest/src/gtest-death-test.cc: In function ‘bool testing::internal::StackGrowsDown()’:
/home/runner/work/overlaybd/overlaybd/googletest-release-1.10.0/googletest/src/gtest-death-test.cc:1301:24: error: ‘dummy’ may be used uninitialized [-Werror=maybe-uninitialized]
 1301 |   StackLowerThanAddress(&dummy, &result);
      |   ~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~
/home/runner/work/overlaybd/overlaybd/googletest-release-1.10.0/googletest/src/gtest-death-test.cc:1290:13: note: by argument 1 of type ‘const void*’ to ‘void testing::internal::StackLowerThanAddress(const void*, bool*)’ declared here
 1290 | static void StackLowerThanAddress(const void* ptr, bool* result) {
      |             ^~~~~~~~~~~~~~~~~~~~~
/home/runner/work/overlaybd/overlaybd/googletest-release-1.10.0/googletest/src/gtest-death-test.cc:1299:7: note: ‘dummy’ declared here
 1299 |   int dummy;
      |       ^~~~~
cc1plus: all warnings being treated as errors
make[2]: *** [googletest/CMakeFiles/gtest.dir/build.make:76: googletest/CMakeFiles/gtest.dir/src/gtest-all.cc.o] Error 1
make[1]: *** [CMakeFiles/Makefile2:172: googletest/CMakeFiles/gtest.dir/all] Error 2
make: *** [Makefile:146: all] Error 2
Error: Process completed with exit code 2.
```
Signed-off-by: Austin Vazquez <macedonv@amazon.com>