### PR TITLE
add overlaybd-apply and extfs for image conversion in user mode

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -24,6 +24,7 @@ jobs:
         sudo apt-get update -y
         sudo apt-get install -y libgflags-dev libcurl4-openssl-dev libssl-dev libaio-dev libnl-3-dev libnl-genl-3-dev libzstd-dev
         sudo apt-get install -y uuid-dev libjson-c-dev libkmod-dev libsystemd-dev autoconf automake libtool libpci-dev nasm
+        sudo apt-get install -y libext2fs-dev
         wget https://github.com/google/googletest/archive/refs/tags/release-1.11.0.tar.gz
         tar -zxvf release-1.11.0.tar.gz
         cd googletest-release-1.11.0/

--- a/.github/workflows/dev-release.yml
+++ b/.github/workflows/dev-release.yml
@@ -21,7 +21,7 @@ jobs:
       run: |
         sudo apt-get update -y
         sudo apt-get install -y libgflags-dev libcurl4-openssl-dev libssl-dev libaio-dev libnl-3-dev libnl-genl-3-dev rpm
-        sudo apt-get install -y uuid-dev libjson-c-dev libkmod-dev libsystemd-dev autoconf automake libtool libpci-dev nasm libzstd-dev
+        sudo apt-get install -y uuid-dev libjson-c-dev libkmod-dev libsystemd-dev autoconf automake libtool libpci-dev nasm libzstd-dev libext2fs-dev
 
     - name: Create Build Environment
       run: cmake -E make_directory ${{github.workspace}}/build

--- a/CMake/Findext2fs.cmake
+++ b/CMake/Findext2fs.cmake
@@ -1,0 +1,15 @@
+include(FetchContent)
+set(FETCHCONTENT_QUIET false)
+
+FetchContent_Declare(
+  ext2fs
+  URL https://github.com/data-accelerator/e2fsprogs/releases/download/latest/libext2fs.tar.gz
+)
+
+FetchContent_GetProperties(ext2fs)
+if (NOT ext2fs_POPULATED)
+  FetchContent_Populate(ext2fs)
+endif()
+
+set(EXT2FS_INCLUDE_DIR ${ext2fs_SOURCE_DIR}/include)
+find_library(EXT2FS_LIBRARY ext2fs HINTS ${ext2fs_SOURCE_DIR}/lib/)

--- a/README.md
+++ b/README.md
@@ -52,9 +52,9 @@ To build overlaybd from source code, the following dependencies are required:
 * gcc/g++ >= 7
 
 * Libaio, libcurl, libnl3, glib2 and openssl runtime and development libraries.
-  * CentOS 7/Fedora: `sudo yum install libaio-devel libcurl-devel openssl-devel libnl3-devel libzstd-static`
-  * CentOS 8: `sudo yum install libaio-devel libcurl-devel openssl-devel libnl3-devel libzstd-devel`
-  * Debian/Ubuntu: `sudo apt install libcurl4-openssl-dev libssl-dev libaio-dev libnl-3-dev libnl-genl-3-dev libgflags-dev libzstd-dev`
+  * CentOS 7/Fedora: `sudo yum install libaio-devel libcurl-devel openssl-devel libnl3-devel libzstd-static e2fsprogs-devel`
+  * CentOS 8: `sudo yum install libaio-devel libcurl-devel openssl-devel libnl3-devel libzstd-devel e2fsprogs-devel`
+  * Debian/Ubuntu: `sudo apt install libcurl4-openssl-dev libssl-dev libaio-dev libnl-3-dev libnl-genl-3-dev libgflags-dev libzstd-dev libext2fs-dev`
 
 #### Build
 
@@ -90,7 +90,7 @@ cmake -D ENABLE_ISAL=1 ..
 
 If you want to use QAT to accelerate compression/decompression.
 
-```bash 
+```bash
 cmake -D ENABLE_QAT=1 ..
 ```
 
@@ -143,7 +143,7 @@ Default configure file `overlaybd.json` is installed to `/etc/overlaybd/`.
 | registryCacheSizeGB | The max size of cache, in GB.                                                                         |
 | cacheType           | Cache type used, `file` and `ocf` are supported, `file` is the default.                               |
 | credentialFilePath(legacy)  | The credential used for fetching images on registry. `/opt/overlaybd/cred.json` is the default value. |
-| credentialConfig.mode | Authentication mode for lazy-loading. <br> - `file` means reading credential from `credentialConfig.path`.  <br> - `http` means sending an http request to `credentialConfig.path` | 
+| credentialConfig.mode | Authentication mode for lazy-loading. <br> - `file` means reading credential from `credentialConfig.path`.  <br> - `http` means sending an http request to `credentialConfig.path` |
 credentialConfig.path | credential file path or url which is determined by `mode`
 | download.enable     | Whether background downloading is enabled or not.                                                     |
 | download.delay      | The seconds waiting to start downloading task after the overlaybd device launched.                    |
@@ -194,7 +194,7 @@ Overlaybd supports serveral credential mode. Here are some example `credentialCo
 ```
 
 - mode **http**
-  
+
   the `credentialConfig.path` should be a server listening address implemented by developers and can reply to credential information.
 
 ```json

--- a/src/overlaybd/CMakeLists.txt
+++ b/src/overlaybd/CMakeLists.txt
@@ -3,6 +3,7 @@ add_subdirectory(lsmt)
 add_subdirectory(zfile)
 add_subdirectory(cache)
 add_subdirectory(untar)
+add_subdirectory(extfs)
 
 file(GLOB SOURCE_OBD "*.cpp")
 add_library(overlaybd_lib STATIC ${SOURCE_OBD})
@@ -16,4 +17,5 @@ target_link_libraries(overlaybd_lib
     zfile_lib
     cache_lib
     untar_lib
+    extfs_lib
 )

--- a/src/overlaybd/extfs/CMakeLists.txt
+++ b/src/overlaybd/extfs/CMakeLists.txt
@@ -1,0 +1,19 @@
+file(GLOB SOURCE_TAR "*.cpp")
+add_library(extfs_lib STATIC ${SOURCE_TAR})
+
+if(CUSTOM_EXT2FS)
+  find_package(ext2fs REQUIRED)
+  target_include_directories(extfs_lib PUBLIC ${EXT2FS_INCLUDE_DIR})
+  set(LIB_EXT2FS ${EXT2FS_LIBRARY})
+
+  install(DIRECTORY ${ext2fs_SOURCE_DIR}/lib DESTINATION /opt/overlaybd/ USE_SOURCE_PERMISSIONS)
+else()
+  set(LIB_EXT2FS ext2fs)
+endif()
+
+target_include_directories(extfs_lib PUBLIC ${PHOTON_INCLUDE_DIR})
+target_link_libraries(extfs_lib photon_static ${LIB_EXT2FS})
+
+if(BUILD_TESTING)
+  add_subdirectory(test)
+endif()

--- a/src/overlaybd/extfs/buffer_file.h
+++ b/src/overlaybd/extfs/buffer_file.h
@@ -1,0 +1,202 @@
+/*
+   Copyright The Overlaybd Authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+#pragma once
+#include <stdint.h>
+#include <assert.h>
+#include <stdlib.h>
+#include <map>
+#include <algorithm>
+#include <photon/fs/filesystem.h>
+#include <photon/fs/forwardfs.h>
+#include <photon/common/alog.h>
+
+photon::fs::IFile *new_buffer_file(photon::fs::IFile *file);
+
+class BufferFile : public photon::fs::ForwardFile {
+public:
+    BufferFile(photon::fs::IFile *file, uint32_t buffer_size = 8 << 20, uint32_t _block_size = 128 << 10)
+    : photon::fs::ForwardFile(file), block_size(_block_size) {
+        if (buffer_size % block_size != 0 \
+        || block_size % EXT_BLOCK_SIZE != 0 \
+        || lowbit(block_size) != block_size) {
+            LOG_ERROR("buffer_size must be a multiple of block_size, " \
+                "block_size must be a multiple of EXT_IO_BLOCK_SIZE, " \
+                "block_size must be a power of 2");
+            return;
+        }
+        block_size_bit = __builtin_ffs(block_size) - 1;
+        block_size_mod = block_size - 1;
+        block_counts = DIV(buffer_size);
+        buffer = (char*) malloc(buffer_size);
+        head = tail = nullptr;
+    }
+    ~BufferFile() {
+        close();
+    }
+    virtual int close() override {
+        for (auto &it : mp) {
+            int ret = flush_node(it.second);
+            if (ret) {
+                return -1;
+            }
+            delete it.second;
+        }
+        free(buffer);
+        LOG_INFO("buffer file flush and close, cache hit: `, cache miss: `, cache hit rate: `%", cache_hit, cache_miss, cache_hit * 100.0 / (cache_hit + cache_miss));
+        LOG_INFO("mem_read: `, mem_write: `, disk_read: `, disk_write: `", mem_read, mem_write, disk_read, disk_write);
+        return 0;
+    }
+    virtual ssize_t pread(void *buf, size_t count, off_t offset) override {
+        if (count != EXT_BLOCK_SIZE || (offset & EXT_BLOCK_SIZE_MOD)) {
+            disk_read += count;
+            return m_file->pread(buf, count, offset);
+        }
+        ListNode *x = get_buffer_block(DIV(offset));
+        if (!x) {
+            LOG_ERROR_RETURN(0, -1, "BufferFile: failed to pread from file to buffer");
+        }
+        off_t buffer_offset = pos(x->buffer_block_id, MOD(offset));
+        mem_read += count;
+        return std::copy_n(buffer + buffer_offset, count, (char*) buf) - (char*) buf;
+    }
+    virtual ssize_t pwrite(const void *buf, size_t count, off_t offset) override {
+        if (count != EXT_BLOCK_SIZE || (offset & EXT_BLOCK_SIZE_MOD)) {
+            disk_write += count;
+            return m_file->pwrite(buf, count, offset);
+        }
+        ListNode *x = get_buffer_block(DIV(offset));
+        if (!x) {
+            LOG_ERROR_RETURN(0, -1, "BufferFile: failed to pwrite from file to buffer");
+        }
+        x->is_dif = true;
+        off_t buffer_offset = pos(x->buffer_block_id, MOD(offset));
+        mem_write += count;
+        return std::copy_n((char*) buf, count, buffer + buffer_offset) - (buffer + buffer_offset);
+    }
+
+private:
+    size_t cache_hit = 0;
+    size_t cache_miss = 0;
+    uint64_t disk_read = 0;
+    uint64_t disk_write = 0;
+    uint64_t mem_read = 0;
+    uint64_t mem_write = 0;
+    static const uint32_t EXT_BLOCK_SIZE = 4 << 10;  // ext I/O block size
+
+    uint32_t block_size;  // cache block size
+    size_t block_counts;
+    char *buffer;
+
+    // LRU index data struct
+    struct ListNode {
+        bool is_dif;
+        ListNode* prv;
+        ListNode* nxt;
+        off_t block_id;
+        off_t buffer_block_id;
+        ListNode(): prv(nullptr), nxt(nullptr), block_id(0), buffer_block_id(0), is_dif(false) {};
+    };
+    std::map<off_t, ListNode*> mp;
+    ListNode *head, *tail;
+
+    ListNode *get_buffer_block(off_t block_id) {
+        ListNode *x;
+        if (mp.count(block_id)) {
+            x = mp[block_id];
+            pop_node(x);
+            cache_hit++;
+        } else {
+            cache_miss++;
+            // cache miss
+            assert(mp.size() <= block_counts);
+            if (mp.size() != block_counts) {
+                x = new ListNode();
+                x->block_id = block_id;
+                x->buffer_block_id = mp.size();
+            } else {
+                x = tail;
+                int ret = flush_node(tail);
+                if (ret) {
+                    return nullptr;
+                }
+                pop_node(tail);
+                mp.erase(x->block_id);
+                x->block_id = block_id;
+            }
+            disk_read += block_size;
+            auto ret = m_file->pread(buffer + pos(x->buffer_block_id, 0), block_size, pos(x->block_id, 0));
+            if (ret != block_size) {
+                return nullptr;
+            }
+            mp[block_id] = x;
+        }
+        push_node(x);
+        return x;
+    }
+
+    inline off_t pos(off_t block_id, off_t offset) {
+        return MULT(block_id) + offset;
+    }
+    void pop_node(ListNode *x) {
+        if (x == head) head = head->nxt;
+        if (x == tail) tail = tail->prv;
+        ListNode *prv = x->prv;
+        ListNode *nxt = x->nxt;
+        if (prv) prv->nxt = nxt;
+        if (nxt) nxt->prv = prv;
+        x->prv = nullptr;
+        x->nxt = nullptr;
+    }
+    void push_node(ListNode *x) {
+        if (head) head->prv = x;
+        x->nxt = head;
+        head = x;
+        if (!tail) tail = x;
+    }
+    int flush_node(ListNode *x) {
+        if (!(x->is_dif)) return 0;
+
+        disk_write += block_size;
+        ssize_t ret = m_file->pwrite(buffer + pos(x->buffer_block_id, 0), block_size, pos(x->block_id, 0));
+        if (ret != block_size) {
+            LOG_ERRNO_RETURN(0, -1, "BufferFile: failed to flush node");
+        }
+        return 0;
+    }
+
+    // bit calc
+    static const uint32_t EXT_BLOCK_SIZE_MOD = EXT_BLOCK_SIZE - 1;
+    uint16_t block_size_bit;  // __builtin_ffs(block_size)
+    uint32_t block_size_mod;  // block_size-1
+    int64_t lowbit(int64_t x) {
+        return x & (-x);
+    }
+    inline off_t DIV(off_t x) {
+        return x >> block_size_bit;
+    }
+    inline off_t MOD(off_t x) {
+        return x & block_size_mod;
+    }
+    inline off_t MULT(off_t x) {
+        return x << block_size_bit;
+    }
+};
+
+photon::fs::IFile *new_buffer_file(photon::fs::IFile *file) {
+    photon::fs::IFile *buffer_file = new BufferFile(file);
+    return buffer_file;
+}

--- a/src/overlaybd/extfs/extfs.cpp
+++ b/src/overlaybd/extfs/extfs.cpp
@@ -1,0 +1,1028 @@
+/*
+   Copyright The Overlaybd Authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+#include <utime.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <limits.h>
+#include <string>
+#include <sstream>
+#include <sys/types.h>
+#include <unistd.h>
+#include <vector>
+#include <sys/sysmacros.h>
+
+#include <photon/photon.h>
+#include <photon/common/alog.h>
+#include <photon/common/alog-stdstring.h>
+#include <photon/common/estring.h>
+#include <photon/common/expirecontainer.h>
+#include <photon/fs/filesystem.h>
+#include <photon/fs/localfs.h>
+#include <photon/fs/virtual-file.h>
+
+#include "extfs.h"
+#include "extfs_utils.h"
+#include "buffer_file.h"
+
+// add for debug
+static uint64_t total_read_cnt = 0;
+static uint64_t total_write_cnt = 0;
+
+ext2_filsys do_ext2fs_open(io_manager extfs_manager) {
+    ext2_filsys fs;
+    errcode_t ret = ext2fs_open(
+        "extfs",
+        EXT2_FLAG_RW,         // flags
+        0,                    // superblock
+        DEFAULT_BLOCK_SIZE,   // block_size
+        extfs_manager,        // io manager
+        &fs                   // ret_fs
+    );
+    if (ret) {
+        errno = -parse_extfs_error(nullptr, 0, ret);
+        LOG_ERROR("failed ext2fs_open, errno `:`", errno, strerror(errno));
+        return nullptr;
+    }
+    ret = ext2fs_read_bitmaps(fs);
+    if (ret) {
+        errno = -parse_extfs_error(fs, 0, ret);
+        LOG_ERROR("failed ext2fs_read_bitmaps, errno `:`", errno, strerror(errno));
+        ext2fs_close(fs);
+        return nullptr;
+    }
+    LOG_INFO("ext2fs opened");
+    return fs;
+}
+
+ext2_file_t do_ext2fs_open_file(ext2_filsys fs, const char *path, unsigned int flags, unsigned int mode) {
+    DEFER(LOG_DEBUG("open_file" , VALUE(path)));
+    ext2_ino_t ino = string_to_inode(fs, path, !(flags & O_NOFOLLOW));
+    errcode_t ret;
+    if (ino == 0) {
+        if (!(flags & O_CREAT)) {
+            errno = ENOENT;
+            return nullptr;
+        }
+        ret = create_file(fs, path, mode, &ino);
+        if (ret) {
+            errno = -ret;
+            LOG_ERROR("failed to create file ", VALUE(ret), VALUE(path));
+            return nullptr;
+        }
+    } else if (flags & O_EXCL) {
+        errno = EEXIST;
+        return nullptr;
+    }
+    if ((flags & O_DIRECTORY) && ext2fs_check_directory(fs, ino)) {
+        errno = ENOTDIR;
+        return nullptr;
+    }
+    ext2_file_t file;
+    ret = ext2fs_file_open(fs, ino, extfs_open_flags(flags), &file);
+    if (ret) {
+        errno = -parse_extfs_error(fs, ino, ret);
+        return nullptr;
+    }
+    if (flags & O_TRUNC) {
+        ret = ext2fs_file_set_size2(file, 0);
+        if (ret) {
+            errno = -parse_extfs_error(fs, ino, ret);
+            return nullptr;
+        }
+    }
+    return file;
+}
+
+long do_ext2fs_read(
+    ext2_file_t file,
+    int flags,
+    char *buffer,
+    size_t count,  // requested count
+    off_t offset  // offset in file, -1 for current offset
+) {
+    errcode_t ret = 0;
+    if ((flags & O_WRONLY) != 0) {
+        // Don't try to read write only files.
+        return -EBADF;
+    }
+    if (offset != -1) {
+        ret = ext2fs_file_llseek(file, offset, EXT2_SEEK_SET, NULL);
+        if (ret) return parse_extfs_error(nullptr, 0, ret);
+    }
+    unsigned int got;
+    LOG_DEBUG("read ", VALUE(offset), VALUE(count));
+    ret = ext2fs_file_read(file, buffer, count, &got);
+    if (ret) return parse_extfs_error(nullptr, 0, ret);
+    total_read_cnt += got;
+    if ((flags & O_NOATIME) == 0) {
+        ret = update_xtime(file, EXT_ATIME);
+        if (ret) return ret;
+    }
+    return got;
+}
+
+long do_ext2fs_write(
+    ext2_file_t file,
+    int flags,
+    const char *buffer,
+    size_t count,  // requested count
+    off_t offset  // offset in file, -1 for current offset
+) {
+    if ((flags & (O_WRONLY | O_RDWR)) == 0) {
+        // Don't try to write to readonly files.
+        return -EBADF;
+    }
+    errcode_t ret = 0;
+    if ((flags & O_APPEND) != 0) {
+        // append mode: seek to the end before each write
+        ret = ext2fs_file_llseek(file, 0, EXT2_SEEK_END, NULL);
+    } else if (offset != -1) {
+        ret = ext2fs_file_llseek(file, offset, EXT2_SEEK_SET, NULL);
+    }
+
+    if (ret) return parse_extfs_error(nullptr, 0, ret);
+    unsigned int written;
+    LOG_DEBUG("write ", VALUE(offset), VALUE(count));
+    ret = ext2fs_file_write(file, buffer, count, &written);
+    if (ret) return parse_extfs_error(nullptr, 0, ret);
+    total_write_cnt += written;
+    // update_mtime
+    ret = update_xtime(file, EXT_CTIME | EXT_MTIME);
+    if (ret) return ret;
+
+    ret = ext2fs_file_flush(file);
+    if (ret) {
+        return parse_extfs_error(nullptr, 0, ret);
+    }
+
+    return written;
+}
+
+int do_ext2fs_chmod(ext2_filsys fs, ext2_ino_t ino, int mode) {
+    struct ext2_inode inode;
+    memset(&inode, 0, sizeof(inode));
+
+    errcode_t ret = ext2fs_read_inode(fs, ino, &inode);
+    if (ret) return parse_extfs_error(fs, ino, ret);
+
+    // keep only fmt (file or directory)
+    inode.i_mode &= LINUX_S_IFMT;
+    // apply new mode
+    inode.i_mode |= (mode & ~LINUX_S_IFMT);
+    increment_version(&inode);
+
+    ret = ext2fs_write_inode(fs, ino, &inode);
+    if (ret) return parse_extfs_error(fs, ino, ret);
+
+    return 0;
+}
+
+int do_ext2fs_chmod(ext2_filsys fs, const char *path, int mode) {
+    LOG_DEBUG(VALUE(path));
+    ext2_ino_t ino = string_to_inode(fs, path, 0);
+    if (!ino) return -ENOENT;
+
+    return do_ext2fs_chmod(fs, ino, mode);
+}
+
+int do_ext2fs_chown(ext2_filsys fs, ext2_ino_t ino, int uid, int gid) {
+    struct ext2_inode inode;
+    memset(&inode, 0, sizeof(inode));
+
+    // TODO handle 32 bit {u,g}ids
+    errcode_t ret = ext2fs_read_inode(fs, ino, &inode);
+    if (ret) return parse_extfs_error(fs, ino, ret);
+    // keep only the lower 16 bits
+    inode.i_uid = uid & 0xFFFF;
+    ext2fs_set_i_uid_high(inode, uid >> 16);
+    inode.i_gid = gid & 0xFFFF;
+    ext2fs_set_i_gid_high(inode, gid >> 16);
+    increment_version(&inode);
+
+    ret = ext2fs_write_inode(fs, ino, &inode);
+    if (ret) return parse_extfs_error(fs, ino, ret);
+
+    return 0;
+}
+
+int do_ext2fs_chown(ext2_filsys fs, const char *path, int uid, int gid, int follow) {
+    LOG_DEBUG(VALUE(path));
+    ext2_ino_t ino = string_to_inode(fs, path, follow);
+    if (!ino) return -ENOENT;
+
+    return do_ext2fs_chown(fs, ino, uid, gid);
+}
+
+int do_ext2fs_utimes(ext2_filsys fs, ext2_ino_t ino, const struct timeval tv[2]) {
+    struct ext2_inode inode;
+    memset(&inode, 0, sizeof(inode));
+
+    errcode_t ret = ext2fs_read_inode(fs, ino, &inode);
+    if (ret) return parse_extfs_error(fs, ino, ret);
+
+    inode.i_atime = tv[0].tv_sec;
+    inode.i_mtime = tv[1].tv_sec;
+    inode.i_ctime = tv[1].tv_sec;
+    increment_version(&inode);
+
+    ret = ext2fs_write_inode(fs, ino, &inode);
+    if (ret) return parse_extfs_error(fs, ino, ret);
+
+    return 0;
+}
+
+int do_ext2fs_utimes(ext2_filsys fs, const char *path, const struct timeval tv[2], int follow) {
+    LOG_DEBUG(VALUE(path));
+    ext2_ino_t ino = string_to_inode(fs, path, follow);
+    if (!ino) return -ENOENT;
+
+    return do_ext2fs_utimes(fs, ino, tv);
+}
+
+int do_ext2fs_unlink(ext2_filsys fs, const char *path) {
+    ext2_ino_t ino;
+    errcode_t ret = 0;
+
+    DEFER(LOG_DEBUG("unlink ", VALUE(path), VALUE(ino), VALUE(ret)));
+    ino = string_to_inode(fs, path, 0, true);
+    if (ino == 0) {
+        ret = ENOENT;
+        return -ENOENT;
+    }
+
+    if (ext2fs_check_directory(fs, ino) == 0) {
+        ret = EISDIR;
+        return -EISDIR;
+    }
+
+    ret = unlink_file_by_name(fs, path);
+    if (ret) return ret;
+
+    ret = remove_inode(fs, ino);
+    if (ret) return ret;
+
+    return 0;
+}
+
+int do_ext2fs_mkdir(ext2_filsys fs, const char *path, int mode) {
+    ext2_ino_t parent, ino;
+    errcode_t ret = 0;
+
+    DEFER(LOG_DEBUG("mkdir ", VALUE(path), VALUE(parent), VALUE(ino), VALUE(ret)));
+    ino = string_to_inode(fs, path, 0);
+    if (ino) {
+        ret = EEXIST;
+        return -EEXIST;
+    }
+    parent = get_parent_dir_ino(fs, path);
+    if (parent == 0) {
+        ret = ENOTDIR;
+        return -ENOTDIR;
+    }
+    char *filename = get_filename(path);
+    if (filename == nullptr) {
+        // This should never happen.
+        ret = EISDIR;
+        return -EISDIR;
+    }
+
+    ret = ext2fs_new_inode(fs, parent, LINUX_S_IFDIR, 0, &ino);
+    if (ret) return parse_extfs_error(fs, 0, ret);
+    ret = ext2fs_mkdir(fs, parent, ino, filename);
+    if (ret == EXT2_ET_DIR_NO_SPACE) {
+        ret = ext2fs_expand_dir(fs, parent);
+        if (ret) return parse_extfs_error(fs, 0, ret);
+        LOG_WARN("ext2fs_expand_mkdir ", VALUE(parent));
+        ret = ext2fs_mkdir(fs, parent, ino, filename);
+    }
+    if (ret) return parse_extfs_error(fs, 0, ret);
+
+    struct ext2_inode_large inode;
+    memset(&inode, 0, sizeof(inode));
+    ret = ext2fs_read_inode_full(fs, ino, (struct ext2_inode *)&inode, sizeof(inode));
+    if (ret) return parse_extfs_error(fs, 0, ret);
+    inode.i_mode = (mode & ~LINUX_S_IFMT) | LINUX_S_IFDIR;
+    ret = ext2fs_write_inode_full(fs, ino, (struct ext2_inode *)&inode, sizeof(inode));
+    if (ret) return parse_extfs_error(fs, 0, ret);
+
+    return 0;
+}
+
+int do_ext2fs_rmdir(ext2_filsys fs, const char *path) {
+    ext2_ino_t ino;
+    errcode_t ret = 0;
+    struct rd_struct rds;
+
+    DEFER(LOG_DEBUG("rmdir ", VALUE(path), VALUE(ino), VALUE(ret)));
+    ino = string_to_inode(fs, path, 0, true);
+    if (ino == 0) {
+        ret = ENOENT;
+        return -ENOENT;
+    }
+
+    rds.parent = 0;
+    rds.empty = 1;
+
+    ret = ext2fs_dir_iterate2(fs, ino, 0, 0, rmdir_proc, &rds);
+    if (ret) return parse_extfs_error(fs, ino, ret);
+
+    if (rds.empty == 0) {
+        ret = ENOTEMPTY;
+        return -ENOTEMPTY;
+    }
+
+    ret = unlink_file_by_name(fs, path);
+    if (ret) return ret;
+    /* Directories have to be "removed" twice. */
+    ret = remove_inode(fs, ino);
+    if (ret) return ret;
+    ret = remove_inode(fs, ino);
+    if (ret) return ret;
+
+    if (rds.parent) {
+        struct ext2_inode_large inode;
+        memset(&inode, 0, sizeof(inode));
+        ret = ext2fs_read_inode_full(fs, rds.parent, (struct ext2_inode *)&inode, sizeof(inode));
+        if (ret) return parse_extfs_error(fs, rds.parent, ret);
+
+        if (inode.i_links_count > 1)
+            inode.i_links_count--;
+        // update_mtime
+        ret = update_xtime(fs, rds.parent, (struct ext2_inode *)&inode, EXT_CTIME | EXT_MTIME);
+        if (ret) return ret;
+        ret = ext2fs_write_inode_full(fs, rds.parent, (struct ext2_inode *)&inode, sizeof(inode));
+        if (ret) return parse_extfs_error(fs, rds.parent, ret);
+    }
+
+    return 0;
+}
+
+int do_ext2fs_rename(ext2_filsys fs, const char *from, const char *to) {
+    errcode_t ret = 0;
+    ext2_ino_t from_ino, to_ino, to_dir_ino, from_dir_ino;
+    struct ext2_inode inode;
+    struct update_dotdot ud;
+
+    DEFER(LOG_DEBUG("rename ", VALUE(from), VALUE(to), VALUE(from_ino), VALUE(to_ino), VALUE(ret)));
+
+    from_ino = string_to_inode(fs, from, 0, true);
+    if (from_ino == 0) {
+        ret = ENOENT;
+        return -ENOENT;
+    }
+    to_ino = string_to_inode(fs, to, 0);
+    if (to_ino == 0 && errno != ENOENT) {
+        ret = errno;
+        return -errno;
+    }
+
+    /* Already the same file? */
+    if (to_ino != 0 && to_ino == from_ino)
+        return 0;
+
+    /* Find parent dir of the source and check write access */
+    from_dir_ino = get_parent_dir_ino(fs, from);
+    if (from_dir_ino == 0) {
+        ret = ENOTDIR;
+        return -ENOTDIR;
+    }
+
+    /* Find parent dir of the destination and check write access */
+    to_dir_ino = get_parent_dir_ino(fs, to);
+    if (to_dir_ino == 0) {
+        ret = ENOTDIR;
+        return -ENOTDIR;
+    }
+    char *filename = get_filename(to);
+    if (filename == nullptr) {
+        ret = EISDIR;
+        return -EISDIR;
+    }
+
+    /* If the target exists, unlink it first */
+    if (to_ino != 0) {
+        ret = ext2fs_read_inode(fs, to_ino, &inode);
+        if (ret) return parse_extfs_error(fs, to_ino, ret);
+
+        LOG_DEBUG("unlinking ` ino=`", LINUX_S_ISDIR(inode.i_mode) ? "dir" : "file", to_ino);
+        if (LINUX_S_ISDIR(inode.i_mode))
+            ret = do_ext2fs_rmdir(fs, to);
+        else
+            ret = do_ext2fs_unlink(fs, to);
+        if (ret) return ret;
+    }
+
+    /* Get ready to do the move */
+    ret = ext2fs_read_inode(fs, from_ino, &inode);
+    if (ret) return parse_extfs_error(fs, from_ino, ret);
+
+    /* Link in the new file */
+    LOG_DEBUG("linking ino=`/path=` to dir=`", from_ino, filename, to_dir_ino);
+    ret = ext2fs_link(fs, to_dir_ino, filename, from_ino, ext2_file_type(inode.i_mode));
+    if (ret == EXT2_ET_DIR_NO_SPACE) {
+        ret = ext2fs_expand_dir(fs, to_dir_ino);
+        if (ret) return parse_extfs_error(fs, to_dir_ino, ret);
+
+        ret = ext2fs_link(fs, to_dir_ino, filename, from_ino, ext2_file_type(inode.i_mode));
+    }
+    if (ret) return parse_extfs_error(fs, to_dir_ino, ret);
+
+    /* Update '..' pointer if dir */
+    ret = ext2fs_read_inode(fs, from_ino, &inode);
+    if (ret) return parse_extfs_error(fs, from_ino, ret);
+
+    if (LINUX_S_ISDIR(inode.i_mode)) {
+        ud.new_dotdot = to_dir_ino;
+        LOG_DEBUG("updating .. entry for dir=`", to_dir_ino);
+        ret = ext2fs_dir_iterate2(fs, from_ino, 0, NULL, update_dotdot_helper, &ud);
+        if (ret) return parse_extfs_error(fs, from_ino, ret);
+
+        /* Decrease from_dir_ino's links_count */
+        LOG_DEBUG("moving linkcount from dir=` to dir=`", from_dir_ino, to_dir_ino);
+        ret = ext2fs_read_inode(fs, from_dir_ino, &inode);
+        if (ret) return parse_extfs_error(fs, from_dir_ino, ret);
+        inode.i_links_count--;
+        ret = ext2fs_write_inode(fs, from_dir_ino, &inode);
+        if (ret) return parse_extfs_error(fs, from_dir_ino, ret);
+
+        /* Increase to_dir_ino's links_count */
+        ret = ext2fs_read_inode(fs, to_dir_ino, &inode);
+        if (ret) return parse_extfs_error(fs, to_dir_ino, ret);
+        inode.i_links_count++;
+        ret = ext2fs_write_inode(fs, to_dir_ino, &inode);
+        if (ret) return parse_extfs_error(fs, to_dir_ino, ret);
+    }
+
+    /* Update timestamps */
+    // update_ctime
+    ret = update_xtime(fs, from_ino, nullptr, EXT_CTIME);
+    if (ret) return ret;
+    // update_mtime
+    ret = update_xtime(fs, to_dir_ino, nullptr, EXT_CTIME | EXT_MTIME);
+    if (ret) return ret;
+
+    /* Remove the old file */
+    ret = unlink_file_by_name(fs, from);
+    if (ret) return ret;
+
+    /* Flush the whole mess out */
+    ret = ext2fs_flush2(fs, 0);
+    if (ret) return parse_extfs_error(fs, 0, ret);
+
+    return 0;
+}
+
+int do_ext2fs_link(ext2_filsys fs, const char *src, const char *dest) {
+    errcode_t ret = 0;
+    ext2_ino_t parent, ino;
+
+    DEFER(LOG_DEBUG("link ", VALUE(src), VALUE(dest), VALUE(parent), VALUE(ino), VALUE(ret)));
+
+    ino = string_to_inode(fs, dest, 0);
+    if (ino) {
+        ret = EEXIST;
+        return -EEXIST;
+    }
+    parent = get_parent_dir_ino(fs, dest);
+    if (parent == 0) {
+        ret = ENOTDIR;
+        return -ENOTDIR;
+    }
+    char *filename = get_filename(dest);
+    if (filename == nullptr) {
+        ret = EISDIR;
+        return -EISDIR;
+    }
+    ino = string_to_inode(fs, src, 0);
+    if (ino == 0) {
+        ret = ENOENT;
+        return -ENOENT;
+    }
+
+    struct ext2_inode_large inode;
+    memset(&inode, 0, sizeof(inode));
+    ret = ext2fs_read_inode_full(fs, ino, (struct ext2_inode *)&inode, sizeof(inode));
+    if (ret) return parse_extfs_error(fs, ino, ret);
+
+    inode.i_links_count++;
+    // update_ctime
+    ret = update_xtime(fs, ino, (struct ext2_inode *)&inode, EXT_CTIME);
+    if (ret) return ret;
+
+    ret = ext2fs_write_inode_full(fs, ino, (struct ext2_inode *)&inode, sizeof(inode));
+    if (ret) return parse_extfs_error(fs, ino, ret);
+
+    ret = ext2fs_link(fs, parent, filename, ino, ext2_file_type(inode.i_mode));
+    if (ret == EXT2_ET_DIR_NO_SPACE) {
+        ret = ext2fs_expand_dir(fs, parent);
+        if (ret) return parse_extfs_error(fs, parent, ret);
+
+        ret = ext2fs_link(fs, parent, filename, ino, ext2_file_type(inode.i_mode));
+    }
+    if (ret) return parse_extfs_error(fs, parent, ret);
+
+    // update_mtime
+    ret = update_xtime(fs, parent, nullptr, EXT_CTIME | EXT_MTIME);
+    if (ret) return ret;
+
+    return 0;
+}
+
+int do_ext2fs_symlink(ext2_filsys fs, const char *src, const char *dest) {
+    ext2_ino_t parent, ino;
+    errcode_t ret = 0;
+
+    DEFER(LOG_DEBUG("symlink ", VALUE(src), VALUE(dest), VALUE(parent), VALUE(ino), VALUE(ret)));
+
+    ino = string_to_inode(fs, dest, 0);
+    if (ino) {
+        ret = EEXIST;
+        return -EEXIST;
+    }
+    parent = get_parent_dir_ino(fs, dest);
+    if (parent == 0) {
+        ret = ENOTDIR;
+        return -ENOTDIR;
+    }
+    char *filename = get_filename(dest);
+    if (filename == nullptr) {
+        ret = EISDIR;
+        return -EISDIR;
+    }
+
+    /* Create symlink */
+    ret = ext2fs_symlink(fs, parent, 0, filename, src);
+    if (ret == EXT2_ET_DIR_NO_SPACE) {
+        ret = ext2fs_expand_dir(fs, parent);
+        if (ret) return parse_extfs_error(fs, parent, ret);
+
+        ret = ext2fs_symlink(fs, parent, 0, filename, src);
+    }
+    if (ret) return parse_extfs_error(fs, parent, ret);
+
+    /* Update parent dir's mtime */
+    ret = update_xtime(fs, parent, nullptr, EXT_CTIME | EXT_MTIME);
+    if (ret) return ret;
+
+    /* Still have to update the uid/gid of the symlink */
+    ino = string_to_inode(fs, dest, 0);
+    if (ino == 0) {
+        ret = ENOTDIR;
+        return -ENOTDIR;
+    }
+
+    struct ext2_inode_large inode;
+    memset(&inode, 0, sizeof(inode));
+    ret = ext2fs_read_inode_full(fs, ino, (struct ext2_inode *)&inode, sizeof(inode));
+    if (ret) return parse_extfs_error(fs, ino, ret);
+
+    ret = ext2fs_write_inode_full(fs, ino, (struct ext2_inode *)&inode, sizeof(inode));
+    if (ret) return parse_extfs_error(fs, ino, ret);
+
+    return 0;
+}
+
+int do_ext2fs_mknod(ext2_filsys fs, const char *path, unsigned int st_mode, unsigned int st_rdev) {
+    ext2_ino_t parent, ino;
+    errcode_t ret = 0;
+    unsigned long devmajor, devminor;
+    int filetype;
+
+    DEFER(LOG_DEBUG("mknod ", VALUE(path), VALUE(parent), VALUE(ino), VALUE(ret)));
+    ino = string_to_inode(fs, path, 0);
+    if (ino) {
+        ret = EEXIST;
+        return -EEXIST;
+    }
+
+    parent = get_parent_dir_ino(fs, path);
+    if (parent == 0) {
+        ret = ENOTDIR;
+        return -ENOTDIR;
+    }
+
+    char *filename = get_filename(path);
+    if (filename == nullptr) {
+        ret = EISDIR;
+        return -EISDIR;
+    }
+
+    switch (st_mode & S_IFMT) {
+        case S_IFCHR:
+            filetype = EXT2_FT_CHRDEV;
+            break;
+        case S_IFBLK:
+            filetype = EXT2_FT_BLKDEV;
+            break;
+        case S_IFIFO:
+            filetype = EXT2_FT_FIFO;
+            break;
+#ifndef _WIN32
+        case S_IFSOCK:
+            filetype = EXT2_FT_SOCK;
+            break;
+#endif
+        default:
+            return EXT2_ET_INVALID_ARGUMENT;
+    }
+
+    ret = ext2fs_new_inode(fs, parent, 010755, 0, &ino);
+    if (ret) return parse_extfs_error(fs, 0, ret);
+
+    ret = ext2fs_link(fs, parent, filename, ino, filetype);
+    if (ret == EXT2_ET_DIR_NO_SPACE) {
+        ret = ext2fs_expand_dir(fs, parent);
+        if (ret) return parse_extfs_error(fs, parent, ret);
+
+        ret = ext2fs_link(fs, parent, filename, ino, filetype);
+    }
+    if (ret) return parse_extfs_error(fs, parent, ret);
+
+    if (ext2fs_test_inode_bitmap2(fs->inode_map, ino))
+        LOG_WARN("Warning: inode already set");
+    ext2fs_inode_alloc_stats2(fs, ino, +1, 0);
+
+    struct ext2_inode inode;
+    memset(&inode, 0, sizeof(inode));
+    inode.i_mode = st_mode;
+    inode.i_atime = inode.i_ctime = inode.i_mtime =
+        fs->now ? fs->now : time(0);
+
+    if (filetype != S_IFIFO) {
+        devmajor = major(st_rdev);
+        devminor = minor(st_rdev);
+
+        if ((devmajor < 256) && (devminor < 256)) {
+            inode.i_block[0] = devmajor * 256 + devminor;
+            inode.i_block[1] = 0;
+        } else {
+            inode.i_block[0] = 0;
+            inode.i_block[1] = (devminor & 0xff) | (devmajor << 8) |
+                               ((devminor & ~0xff) << 12);
+        }
+    }
+    inode.i_links_count = 1;
+
+    ret = ext2fs_write_new_inode(fs, ino, &inode);
+    if (ret) return parse_extfs_error(fs, ino, ret);
+
+    return 0;
+}
+
+int do_ext2fs_stat(ext2_filsys fs, ext2_ino_t ino, struct stat *statbuf) {
+    dev_t fakedev = 0;
+    errcode_t ret;
+    struct timespec tv;
+
+    struct ext2_inode_large inode;
+    memset(&inode, 0, sizeof(inode));
+    ret = ext2fs_read_inode_full(fs, ino, (struct ext2_inode *)&inode, sizeof(inode));
+    if (ret) return parse_extfs_error(fs, ino, ret);
+
+    memcpy(&fakedev, fs->super->s_uuid, sizeof(fakedev));
+    statbuf->st_dev = fakedev;
+    statbuf->st_ino = ino;
+    statbuf->st_mode = inode.i_mode;
+    statbuf->st_nlink = inode.i_links_count;
+    statbuf->st_uid = inode_uid(inode);
+    statbuf->st_gid = inode_gid(inode);
+    statbuf->st_size = EXT2_I_SIZE(&inode);
+    statbuf->st_blksize = fs->blocksize;
+    statbuf->st_blocks = blocks_from_inode(fs, (struct ext2_inode *)&inode);
+    statbuf->st_atime = inode.i_atime;
+    statbuf->st_mtime = inode.i_mtime;
+    statbuf->st_ctime = inode.i_ctime;
+    if (LINUX_S_ISCHR(inode.i_mode) ||
+        LINUX_S_ISBLK(inode.i_mode)) {
+        if (inode.i_block[0])
+            statbuf->st_rdev = inode.i_block[0];
+        else
+            statbuf->st_rdev = inode.i_block[1];
+    }
+
+    return 0;
+}
+
+int do_ext2fs_stat(ext2_filsys fs, const char *path, struct stat *statbuf, int follow) {
+    LOG_DEBUG(VALUE(path));
+    ext2_ino_t ino = string_to_inode(fs, path, follow);
+    if (!ino) return -ENOENT;
+
+    return do_ext2fs_stat(fs, ino, statbuf);
+}
+
+int do_ext2fs_readdir(ext2_filsys fs, const char *path, std::vector<::dirent> *dirs) {
+    ext2_ino_t ino = string_to_inode(fs, path, 1);
+    if (ino == 0) {
+        return -ENOENT;
+    }
+    ext2_file_t file;
+    errcode_t ret = ext2fs_file_open(
+        fs,
+        ino,  // inode,
+        0,    // flags TODO
+        &file);
+    if (ret) return parse_extfs_error(fs, ino, ret);
+    ret = ext2fs_check_directory(fs, ino);
+    if (ret) return parse_extfs_error(fs, ino, ret);
+    auto block_buf = (char *)malloc(fs->blocksize);
+    ret = ext2fs_dir_iterate(
+        fs,
+        ino,
+        0,  // flags
+        block_buf,
+        copy_dirent_to_result,
+        (void *)dirs);
+    free(block_buf);
+    if (ret) return parse_extfs_error(fs, ino, ret);
+
+    return 0;
+}
+
+#define DO_EXT2FS(func) \
+    auto ret = func;    \
+    if (ret < 0) {      \
+        errno = -ret;   \
+        return -1;      \
+    }                   \
+    return ret;
+
+class ExtFile : public photon::fs::VirtualFile {
+public:
+    ExtFile(ext2_file_t _file) : file(_file) {
+        fs = ext2fs_file_get_fs(file);
+        ino = ext2fs_file_get_inode_num(file);
+    }
+
+    ~ExtFile() {
+        close();
+    }
+
+    virtual ssize_t pread(void *buf, size_t count, off_t offset) override {
+        DO_EXT2FS(do_ext2fs_read(file, O_RDONLY, (char *)buf, count, offset))
+    }
+    virtual ssize_t pwrite(const void *buf, size_t count, off_t offset) override {
+        DO_EXT2FS(do_ext2fs_write(file, O_RDWR, (const char *)buf, count, offset))
+    }
+    virtual int fchmod(mode_t mode) override {
+        DO_EXT2FS(do_ext2fs_chmod(fs, ino, mode))
+    }
+    virtual int fchown(uid_t owner, gid_t group) override {
+        DO_EXT2FS(do_ext2fs_chown(fs, ino, owner, group))
+    }
+    virtual int futimes(const struct timeval tv[2]) {
+        DO_EXT2FS(do_ext2fs_utimes(fs, ino, tv))
+    }
+    virtual int fstat(struct stat *buf) override {
+        DO_EXT2FS(do_ext2fs_stat(fs, ino, buf))
+    }
+    virtual int close() override {
+        DO_EXT2FS(ext2fs_file_close(file))
+    }
+
+    UNIMPLEMENTED_POINTER(photon::fs::IFileSystem *filesystem() override);
+    UNIMPLEMENTED(int fsync() override);
+    UNIMPLEMENTED(int fdatasync() override);
+    UNIMPLEMENTED(int ftruncate(off_t length) override);
+
+private:
+    ext2_file_t file;
+    ext2_filsys fs;
+    ext2_ino_t ino;
+};
+
+class ExtDIR : public photon::fs::DIR {
+public:
+    std::vector<::dirent> m_dirs;
+    ::dirent *direntp = nullptr;
+    long loc;
+    ExtDIR(std::vector<::dirent> &dirs) : loc(0) {
+        m_dirs = std::move(dirs);
+        next();
+    }
+    virtual ~ExtDIR() override {
+        closedir();
+    }
+    virtual int closedir() override {
+        if (!m_dirs.empty()) {
+            m_dirs.clear();
+        }
+        return 0;
+    }
+    virtual dirent *get() override {
+        return direntp;
+    }
+    virtual int next() override {
+        if (!m_dirs.empty()) {
+            if (loc < (long) m_dirs.size()) {
+                direntp = &m_dirs[loc++];
+            } else {
+                direntp = nullptr;
+            }
+        }
+        return direntp != nullptr ? 1 : 0;
+    }
+    virtual void rewinddir() override {
+        loc = 0;
+        next();
+    }
+    virtual void seekdir(long loc) override {
+        this->loc = loc;
+        next();
+    }
+    virtual long telldir() override {
+        return loc;
+    }
+};
+
+static const uint64_t kMinimalInoLife = 1L * 1000 * 1000; // ino lives at least 1s
+class ExtFileSystem : public photon::fs::IFileSystem {
+public:
+    ext2_filsys fs;
+    IOManager *extfs_manager = nullptr;
+    ExtFileSystem(photon::fs::IFile *_image_file, bool buffer = true) : ino_cache(kMinimalInoLife) {
+        if (buffer) {
+            buffer_file = new_buffer_file(_image_file);
+            extfs_manager = new_io_manager(buffer_file);
+        } else {
+            extfs_manager = new_io_manager(_image_file);
+        }
+        fs = do_ext2fs_open(extfs_manager->get_io_manager());
+        memset(fs->reserved, 0, sizeof(fs->reserved));
+        auto reserved = reinterpret_cast<std::uintptr_t *>(fs->reserved);
+        reserved[0] = reinterpret_cast<std::uintptr_t>(this);
+    }
+    ~ExtFileSystem() {
+        if (fs) {
+            ext2fs_flush(fs);
+            ext2fs_close(fs);
+            LOG_INFO("ext2fs flushed and closed");
+        }
+        delete extfs_manager;
+        delete buffer_file;
+        LOG_INFO(VALUE(total_read_cnt), VALUE(total_write_cnt));
+    }
+    photon::fs::IFile *open(const char *pathname, int flags, mode_t mode) override {
+        ext2_file_t file = do_ext2fs_open_file(fs, pathname, flags, mode);
+        if (!file) {
+            return nullptr;
+        }
+        return new ExtFile(file);
+    }
+    photon::fs::IFile *open(const char *pathname, int flags) override {
+        return open(pathname, flags, 0666);
+    }
+
+    int mkdir(const char *pathname, mode_t mode) override {
+        DO_EXT2FS(do_ext2fs_mkdir(fs, pathname, mode))
+    }
+    int rmdir(const char *pathname) override {
+        DO_EXT2FS(do_ext2fs_rmdir(fs, pathname))
+    }
+    int symlink(const char *oldname, const char *newname) override {
+        DO_EXT2FS(do_ext2fs_symlink(fs, oldname, newname))
+    }
+    int link(const char *oldname, const char *newname) override {
+        DO_EXT2FS(do_ext2fs_link(fs, oldname, newname))
+    }
+    int rename(const char *oldname, const char *newname) override {
+        DO_EXT2FS(do_ext2fs_rename(fs, oldname, newname))
+    }
+    int unlink(const char *filename) override {
+        DO_EXT2FS(do_ext2fs_unlink(fs, filename))
+    }
+    int mknod(const char *path, mode_t mode, dev_t dev) override {
+        DO_EXT2FS(do_ext2fs_mknod(fs, path, mode, dev))
+    }
+    int utime(const char *path, const struct utimbuf *file_times) override {
+        struct timeval tv[2];
+        tv[0].tv_sec = file_times->actime;
+        tv[0].tv_usec = 0;
+        tv[1].tv_sec = file_times->modtime;
+        tv[1].tv_usec = 0;
+        DO_EXT2FS(do_ext2fs_utimes(fs, path, tv, 1));
+    }
+    int utimes(const char *path, const struct timeval tv[2]) override {
+        DO_EXT2FS(do_ext2fs_utimes(fs, path, tv, 1));
+    }
+    int lutimes(const char *path, const struct timeval tv[2]) override {
+        DO_EXT2FS(do_ext2fs_utimes(fs, path, tv, 0));
+    }
+    int chown(const char *pathname, uid_t owner, gid_t group) override {
+        DO_EXT2FS(do_ext2fs_chown(fs, pathname, owner, group, 1))
+    }
+    int lchown(const char *pathname, uid_t owner, gid_t group) override {
+        DO_EXT2FS(do_ext2fs_chown(fs, pathname, owner, group, 0))
+    }
+    int chmod(const char *pathname, mode_t mode) override {
+        DO_EXT2FS(do_ext2fs_chmod(fs, pathname, mode))
+    }
+    int stat(const char *path, struct stat *buf) override {
+        DO_EXT2FS(do_ext2fs_stat(fs, path, buf, 1))
+    }
+    int lstat(const char *path, struct stat *buf) override{
+        DO_EXT2FS(do_ext2fs_stat(fs, path, buf, 0))
+    }
+
+    photon::fs::DIR *opendir(const char *path) override {
+        std::vector<::dirent> dirs;
+        auto ret = do_ext2fs_readdir(fs, path, &dirs);
+        if (ret) {
+            errno = -ret;
+            return nullptr;
+        }
+        return new ExtDIR(dirs);
+    }
+
+    IFileSystem *filesystem() {
+        return this;
+    }
+
+    UNIMPLEMENTED_POINTER(photon::fs::IFile *creat(const char *, mode_t) override);
+    UNIMPLEMENTED(ssize_t readlink(const char *filename, char *buf, size_t bufsize) override);
+    UNIMPLEMENTED(int statfs(const char *path, struct statfs *buf) override);
+    UNIMPLEMENTED(int statvfs(const char *path, struct statvfs *buf) override);
+    UNIMPLEMENTED(int access(const char *pathname, int mode) override);
+    UNIMPLEMENTED(int truncate(const char *path, off_t length) override);
+    UNIMPLEMENTED(int syncfs() override);
+
+    ext2_ino_t get_inode(const char *str, int follow, bool release) {
+        ext2_ino_t ino = 0;
+        DEFER(LOG_DEBUG("get_inode ", VALUE(str), VALUE(follow), VALUE(release), VALUE(ino)));
+
+        ext2_ino_t *ptr = nullptr;
+        auto func = [&]() -> ext2_ino_t * {
+            ext2_ino_t *i = new ext2_ino_t;
+            errcode_t ret = 0;
+            if (follow) {
+                ret = ext2fs_namei_follow(fs, EXT2_ROOT_INO, EXT2_ROOT_INO, str, i);
+            } else {
+                auto parent = get_parent_dir_ino(fs, str);
+                if (parent) {
+                    auto filename = get_filename(str);
+                    if (filename)
+                        ret = ext2fs_namei(fs, EXT2_ROOT_INO, parent, filename, i);
+                    else
+                        ret = ext2fs_namei(fs, EXT2_ROOT_INO, EXT2_ROOT_INO, str, i);
+                } else {
+                    ret = ext2fs_namei(fs, EXT2_ROOT_INO, EXT2_ROOT_INO, str, i);
+                }
+            }
+            if (ret) {
+                LOG_DEBUG("ext2fs_namei not found ", VALUE(str), VALUE(follow));
+                errno = -parse_extfs_error(fs, 0, ret);
+                delete i;
+                return nullptr;
+            }
+            LOG_DEBUG("ext2fs_namei ", VALUE(str), VALUE(follow), VALUE(*i));
+            return i;
+        };
+
+        if (follow) {
+            auto b = func();
+            if (b) ino = *b;
+
+        } else {
+            auto b = ino_cache.borrow(str, func);
+            if (b) ino = *b;
+        }
+
+        if (release) {
+            LOG_DEBUG("release ino_cache ", VALUE(str), VALUE(release));
+            auto b = ino_cache.borrow(str);
+            b.recycle(true);
+        }
+
+        return ino;
+    }
+
+private:
+    ObjectCache<estring, ext2_ino_t *> ino_cache;
+    photon::fs::IFile *buffer_file = nullptr;
+};
+
+photon::fs::IFileSystem *new_extfs(photon::fs::IFile *file, bool buffer) {
+    auto extfs = new ExtFileSystem(file, buffer);
+    return extfs->fs ? extfs : nullptr;
+}
+
+ext2_ino_t string_to_inode(ext2_filsys fs, const char *str, int follow, bool release) {
+    auto reserved = reinterpret_cast<std::uintptr_t *>(fs->reserved);
+    auto extfs = reinterpret_cast<ExtFileSystem *>(reserved[0]);
+    LOG_DEBUG("string_to_inode ", VALUE(str), VALUE(follow), VALUE(release));
+    return extfs->get_inode(str, follow, release);
+}

--- a/src/overlaybd/extfs/extfs.h
+++ b/src/overlaybd/extfs/extfs.h
@@ -1,0 +1,30 @@
+/*
+   Copyright The Overlaybd Authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+#pragma once
+#include <ext2fs/ext2fs.h>
+#include <photon/fs/filesystem.h>
+
+#define DEFAULT_BLOCK_SIZE 4096
+
+class IOManager {
+public:
+    virtual io_manager get_io_manager()=0;
+    virtual ~IOManager() {}
+};
+
+IOManager *new_io_manager(photon::fs::IFile *file);
+photon::fs::IFileSystem *new_extfs(photon::fs::IFile *file, bool buffer = true);

--- a/src/overlaybd/extfs/extfs_io.cpp
+++ b/src/overlaybd/extfs/extfs_io.cpp
@@ -1,0 +1,222 @@
+/*
+   Copyright The Overlaybd Authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+#include <sys/stat.h>
+
+#include <photon/common/alog.h>
+#include <photon/common/callback.h>
+#include <photon/thread/thread.h>
+
+#include "extfs.h"
+
+errcode_t extfs_open(const char *name, int flags, io_channel *channel);
+errcode_t extfs_close(io_channel channel);
+errcode_t extfs_set_blksize(io_channel channel, int blksize);
+errcode_t extfs_read_blk(io_channel channel, unsigned long block, int count, void *buf);
+errcode_t extfs_read_blk64(io_channel channel, unsigned long long block, int count, void *buf);
+errcode_t extfs_write_blk(io_channel channel, unsigned long block, int count, const void *buf);
+errcode_t extfs_write_blk64(io_channel channel, unsigned long long block, int count, const void *buf);
+errcode_t extfs_flush(io_channel channel);
+errcode_t extfs_discard(io_channel channel, unsigned long long block, unsigned long long count);
+errcode_t extfs_cache_readahead(io_channel channel, unsigned long long block, unsigned long long count);
+errcode_t extfs_zeroout(io_channel channel, unsigned long long block, unsigned long long count);
+
+struct unix_private_data {
+    int magic;
+    int dev;
+    int flags;
+    int align;
+    int access_time;
+    ext2_loff_t offset;
+    void *bounce;
+    struct struct_io_stats io_stats;
+};
+
+template <typename T>
+struct CallBack;
+
+template <typename Ret, typename... Params>
+struct CallBack<Ret(Params...)> {
+    template <typename... Args>
+    static Ret callback(Args... args) { return cb.fire(args...); }
+    static Delegate<Ret, Params...> cb;
+};
+
+// Initialize the static member.
+template <typename Ret, typename... Params>
+Delegate<Ret, Params...> CallBack<Ret(Params...)>::cb;
+
+// add for debug
+static uint64_t total_read_cnt = 0;
+static uint64_t total_write_cnt = 0;
+
+class ExtfsIOManager : public IOManager {
+public:
+    using OpenFunc = errcode_t(const char *, int, io_channel *);
+    using OpenCallback = CallBack<OpenFunc>;
+
+    ExtfsIOManager(photon::fs::IFile *file) : m_file(file) {
+        OpenCallback::cb.bind(this, &ExtfsIOManager::m_extfs_open);
+        auto extfs_open = static_cast<OpenFunc *>(OpenCallback::callback);
+
+        extfs_io_manager = {
+            .magic              = EXT2_ET_MAGIC_IO_MANAGER,
+            .name               = "extfs I/O Manager",
+            .open               = extfs_open,
+            .close              = extfs_close,
+            .set_blksize        = extfs_set_blksize,
+            .read_blk           = extfs_read_blk,
+            .write_blk          = extfs_write_blk,
+            .flush              = extfs_flush,
+            .write_byte         = nullptr,
+            .set_option         = nullptr,
+            .get_stats          = nullptr,
+            .read_blk64         = extfs_read_blk64,
+            .write_blk64        = extfs_write_blk64,
+            .discard            = extfs_discard,
+            .cache_readahead    = extfs_cache_readahead,
+            .zeroout            = extfs_zeroout,
+            .reserved           = {},
+        };
+    }
+
+    ~ExtfsIOManager() {
+        LOG_INFO(VALUE(total_read_cnt), VALUE(total_write_cnt));
+    }
+
+    virtual io_manager get_io_manager() override {
+        return &extfs_io_manager;
+    }
+
+private:
+    errcode_t m_extfs_open(const char *name, int flags, io_channel *channel) {
+        LOG_INFO(VALUE(name));
+        DEFER(LOG_INFO("opened"));
+        ExtfsIOManager::mutex.lock();
+        DEFER(ExtfsIOManager::mutex.unlock());
+        io_channel io = nullptr;
+        struct unix_private_data *data = nullptr;
+        errcode_t retval;
+        ext2fs_struct_stat st;
+
+        retval = ext2fs_get_mem(sizeof(struct struct_io_channel), &io);
+        if (retval)
+            return -retval;
+        memset(io, 0, sizeof(struct struct_io_channel));
+        io->magic = EXT2_ET_MAGIC_IO_CHANNEL;
+        retval = ext2fs_get_mem(sizeof(struct unix_private_data), &data);
+        if (retval)
+            return -retval;
+
+        io->manager = &extfs_io_manager;
+        retval = ext2fs_get_mem(strlen(name) + 1, &io->name);
+        if (retval)
+            return -retval;
+
+        strcpy(io->name, name);
+        io->private_data = data;
+        io->block_size = 1024;
+        io->read_error = 0;
+        io->write_error = 0;
+        io->refcount = 1;
+        io->flags = 0;
+        io->reserved[0] = reinterpret_cast<std::uintptr_t>(m_file);
+        LOG_DEBUG(VALUE(m_file), VALUE((void *)io->reserved[0]));
+
+        memset(data, 0, sizeof(struct unix_private_data));
+        data->magic = EXT2_ET_MAGIC_UNIX_IO_CHANNEL;
+        data->io_stats.num_fields = 2;
+        data->flags = flags;
+        data->dev = 0;
+
+        *channel = io;
+        return 0;
+    }
+
+    struct struct_io_manager extfs_io_manager;
+    photon::fs::IFile *m_file;
+    static photon::mutex mutex;
+};
+
+// Initialize the static member.
+photon::mutex ExtfsIOManager::mutex;
+
+IOManager *new_io_manager(photon::fs::IFile *file) {
+    return new ExtfsIOManager(file);
+}
+
+errcode_t extfs_close(io_channel channel) {
+    LOG_INFO("extfs close");
+    return ext2fs_free_mem(&channel);
+}
+
+errcode_t extfs_set_blksize(io_channel channel, int blksize) {
+    LOG_DEBUG(VALUE(blksize));
+    channel->block_size = blksize;
+    return 0;
+}
+
+errcode_t extfs_read_blk(io_channel channel, unsigned long block, int count, void *buf) {
+    off_t offset = (ext2_loff_t)block * channel->block_size;
+    ssize_t size = count < 0 ? -count : (ext2_loff_t)count * channel->block_size;
+    auto file = reinterpret_cast<photon::fs::IFile *>(channel->reserved[0]);
+    LOG_DEBUG("read ", VALUE(offset), VALUE(size));
+    auto res = file->pread(buf, size, offset);
+    if (res == size) {
+        total_read_cnt += size;
+        return 0;
+    }
+    LOG_ERROR("failed to pread, got `, expect `", res, size);
+    return -1;
+}
+
+errcode_t extfs_read_blk64(io_channel channel, unsigned long long block, int count, void *buf) {
+    return extfs_read_blk(channel, block, count, buf);
+}
+
+errcode_t extfs_write_blk(io_channel channel, unsigned long block, int count, const void *buf) {
+    off_t offset = (ext2_loff_t)block * channel->block_size;
+    ssize_t size = count < 0 ? -count : (ext2_loff_t)count * channel->block_size;
+    auto file = reinterpret_cast<photon::fs::IFile *>(channel->reserved[0]);
+    LOG_DEBUG("write ", VALUE(offset), VALUE(size));
+    auto res = file->pwrite(buf, size, offset);
+    if (res == size) {
+        total_write_cnt += size;
+        return 0;
+    }
+    LOG_ERROR("failed to pwrite, got `, expect `", res, size);
+    return -1;
+}
+
+errcode_t extfs_write_blk64(io_channel channel, unsigned long long block, int count, const void *buf) {
+    return extfs_write_blk(channel, block, count, buf);
+}
+
+errcode_t extfs_flush(io_channel channel) {
+    return 0;
+}
+
+errcode_t extfs_discard(io_channel channel, unsigned long long block, unsigned long long count) {
+    return 0;
+}
+
+errcode_t extfs_cache_readahead(io_channel channel, unsigned long long block, unsigned long long count) {
+    return 0;
+}
+
+errcode_t extfs_zeroout(io_channel channel, unsigned long long block, unsigned long long count) {
+    return 0;
+}

--- a/src/overlaybd/extfs/extfs_utils.h
+++ b/src/overlaybd/extfs/extfs_utils.h
@@ -1,0 +1,472 @@
+/*
+   Copyright The Overlaybd Authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+#include <fcntl.h>
+#include <dirent.h>
+#include <vector>
+#include <ext2fs/ext2fs.h>
+#include <photon/common/alog.h>
+
+int __parse_extfs_error(ext2_filsys fs, errcode_t err, ext2_ino_t ino, std::string &err_msg);
+
+// parse_extfs_error parse extfs error to unix error code
+// print ERROR log for unclassified extfs error
+#define parse_extfs_error(fs, ino, err) ({                                                      \
+    std::string __msg;                                                                          \
+    int __err = __parse_extfs_error((fs), (err), (ino), __msg);                                 \
+    if (__msg != "") {                                                                          \
+        if (ino) {                                                                              \
+            LOG_ERROR("unclassified ext2fs error: `:` (inode #`)", err, __msg.c_str(), ino);    \
+        } else {                                                                                \
+            LOG_ERROR("unclassified ext2fs error: `:`", err, __msg.c_str());                    \
+        }                                                                                       \
+    }                                                                                           \
+    __err;                                                                                      \
+})
+
+inline void increment_version(struct ext2_inode *inode) {
+    inode->osd1.linux1.l_i_version++;
+}
+
+inline void get_now(struct timespec *now) {
+#ifdef CLOCK_REALTIME
+    if (!clock_gettime(CLOCK_REALTIME, now))
+        return;
+#endif
+    now->tv_sec = time(NULL);
+    now->tv_nsec = 0;
+}
+
+#define EXT_ATIME 1
+#define EXT_CTIME 2
+#define EXT_MTIME 4
+
+int update_xtime(ext2_filsys fs, ext2_ino_t ino, struct ext2_inode *pinode,
+                        int flags, struct timespec *file_time = nullptr) {
+    errcode_t ret = 0;
+    struct ext2_inode inode, *pino;
+
+    if (pinode) {
+        pino = pinode;
+    } else {
+        memset(&inode, 0, sizeof(inode));
+        ret = ext2fs_read_inode(fs, ino, &inode);
+        if (ret)
+            return parse_extfs_error(fs, ino, ret);
+        pino = &inode;
+    }
+
+    struct timespec now;
+    if (!file_time) {
+        get_now(&now);
+    } else {
+        now = *file_time;
+    }
+
+    if (flags & EXT_ATIME) pino->i_atime = now.tv_sec;
+    if (flags & EXT_CTIME) pino->i_ctime = now.tv_sec;
+    if (flags & EXT_MTIME) pino->i_mtime = now.tv_sec;
+    increment_version(pino);
+
+    if (!pinode) {
+        ret = ext2fs_write_inode(fs, ino, &inode);
+        if (ret)
+            return parse_extfs_error(fs, ino, ret);
+    }
+
+    return 0;
+}
+
+int update_xtime(ext2_file_t file, int flags, struct timespec *file_time = nullptr) {
+    errcode_t ret = 0;
+    ext2_filsys fs = ext2fs_file_get_fs(file);
+    ext2_ino_t ino = ext2fs_file_get_inode_num(file);
+    struct ext2_inode *inode = ext2fs_file_get_inode(file);
+
+    ret = ext2fs_read_inode(fs, ino, inode);
+    if (ret) return parse_extfs_error(fs, ino, ret);
+
+    ret = update_xtime(fs, ino, inode, flags, file_time);
+    if (ret) return ret;
+
+    ret = ext2fs_write_inode(fs, ino, inode);
+    if (ret) return parse_extfs_error(fs, ino, ret);
+
+    return 0;
+}
+
+int ext2_file_type(unsigned int mode) {
+    switch (mode & LINUX_S_IFMT) {
+        case LINUX_S_IFLNK:  return EXT2_FT_SYMLINK;
+        case LINUX_S_IFREG:  return EXT2_FT_REG_FILE;
+        case LINUX_S_IFDIR:  return EXT2_FT_DIR;
+        case LINUX_S_IFCHR:  return EXT2_FT_CHRDEV;
+        case LINUX_S_IFBLK:  return EXT2_FT_BLKDEV;
+        case LINUX_S_IFIFO:  return EXT2_FT_FIFO;
+        case LINUX_S_IFSOCK: return EXT2_FT_SOCK;
+        default:             return EXT2_FT_UNKNOWN;
+    }
+}
+
+unsigned int extfs_open_flags(unsigned int flags) {
+    unsigned int ret = 0;
+    if (flags & (O_WRONLY | O_RDWR)) ret |= EXT2_FILE_WRITE;
+    if (flags & O_CREAT) ret |= EXT2_FILE_CREATE;
+    return ret;
+}
+
+ext2_ino_t string_to_inode(ext2_filsys fs, const char *str, int follow, bool release = false);
+
+int unlink_file_by_name(ext2_filsys fs, const char *path) {
+    errcode_t ret = 0;
+    ext2_ino_t ino;
+
+    DEFER(LOG_DEBUG("unlink ", VALUE(path), VALUE(ino), VALUE(ret)));
+    char *filename = strdup(path);
+    DEFER(free(filename););
+    char *base_name;
+
+    base_name = strrchr(filename, '/');
+    if (base_name) {
+        *base_name++ = '\0';
+        ino = string_to_inode(fs, filename, 0);
+        if (ino == 0) {
+            ret = ENOENT;
+            return -ENOENT;
+        }
+    } else {
+        ino = EXT2_ROOT_INO;
+        base_name = filename;
+    }
+
+    ret = ext2fs_unlink(fs, ino, base_name, 0, 0);
+    if (ret) return parse_extfs_error(fs, ino, ret);
+    return update_xtime(fs, ino, nullptr, EXT_CTIME | EXT_MTIME);
+}
+
+int remove_inode(ext2_filsys fs, ext2_ino_t ino) {
+    errcode_t ret_err = 0;
+    errcode_t err = 0;
+
+    DEFER(LOG_DEBUG("remove ", VALUE(ino), VALUE(ret_err)));
+
+    struct ext2_inode_large inode;
+    memset(&inode, 0, sizeof(inode));
+    ret_err = ext2fs_read_inode_full(fs, ino, (struct ext2_inode *)&inode, sizeof(inode));
+    if (ret_err) return parse_extfs_error(fs, ino, ret_err);
+
+    if (inode.i_links_count == 0) return 0;
+    inode.i_links_count--;
+    if (inode.i_links_count == 0) inode.i_dtime = time(0);
+
+    ret_err = update_xtime(fs, ino, (struct ext2_inode *)&inode, EXT_CTIME);
+    if (ret_err) return ret_err;
+
+    if (inode.i_links_count) goto write_out;
+
+    /* Nobody holds this file; free its blocks! */
+    err = ext2fs_free_ext_attr(fs, ino, &inode);
+    if (err) {
+        ret_err = parse_extfs_error(fs, ino, err);
+        LOG_ERROR("ext2fs_free_ext_attr failed, ret_err: `", ret_err);
+        goto write_out;
+    }
+    if (ext2fs_inode_has_valid_blocks2(fs, (struct ext2_inode *)&inode)) {
+        err = ext2fs_punch(fs, ino, (struct ext2_inode *)&inode, NULL, 0, ~0ULL);
+        if (err) {
+            ret_err = parse_extfs_error(fs, ino, err);
+            LOG_ERROR("ext2fs_punch failed, ret_err: `", ret_err);
+            goto write_out;
+        }
+    }
+    ext2fs_inode_alloc_stats2(fs, ino, -1, LINUX_S_ISDIR(inode.i_mode));
+
+write_out:
+    err = ext2fs_write_inode_full(fs, ino, (struct ext2_inode *)&inode, sizeof(inode));
+    if (err) ret_err = parse_extfs_error(fs, ino, err);
+    return ret_err;
+}
+
+struct rd_struct {
+    ext2_ino_t parent;
+    int empty;
+};
+
+int rmdir_proc(
+    ext2_ino_t dir,
+    int entry,
+    struct ext2_dir_entry *dirent,
+    int offset,
+    int blocksize,
+    char *buf,
+    void *priv_data) {
+
+    struct rd_struct *rds = (struct rd_struct *)priv_data;
+
+    if (dirent->inode == 0)
+        return 0;
+    if (((dirent->name_len & 0xFF) == 1) && (dirent->name[0] == '.'))
+        return 0;
+    if (((dirent->name_len & 0xFF) == 2) && (dirent->name[0] == '.') &&
+        (dirent->name[1] == '.')) {
+        rds->parent = dirent->inode;
+        return 0;
+    }
+    rds->empty = 0;
+    return 0;
+}
+
+int __parse_extfs_error(ext2_filsys fs, errcode_t err, ext2_ino_t ino, std::string &err_msg) {
+    if (err < EXT2_ET_BASE) return -err;
+
+    switch (err) {
+        case EXT2_ET_NO_MEMORY: case EXT2_ET_TDB_ERR_OOM:
+            return -ENOMEM;
+
+        case EXT2_ET_INVALID_ARGUMENT: case EXT2_ET_LLSEEK_FAILED:
+            return -EINVAL;
+
+        case EXT2_ET_NO_DIRECTORY:
+            return -ENOTDIR;
+
+        case EXT2_ET_FILE_NOT_FOUND:
+            return -ENOENT;
+
+        case EXT2_ET_TOOSMALL: case EXT2_ET_BLOCK_ALLOC_FAIL: case EXT2_ET_INODE_ALLOC_FAIL: case EXT2_ET_EA_NO_SPACE:
+            return -ENOSPC;
+
+        case EXT2_ET_SYMLINK_LOOP:
+            return -EMLINK;
+
+        case EXT2_ET_FILE_TOO_BIG:
+            return -EFBIG;
+
+        case EXT2_ET_TDB_ERR_EXISTS: case EXT2_ET_FILE_EXISTS: case EXT2_ET_DIR_EXISTS:
+            return -EEXIST;
+
+        case EXT2_ET_MMP_FAILED: case EXT2_ET_MMP_FSCK_ON:
+            return -EBUSY;
+
+        case EXT2_ET_EA_KEY_NOT_FOUND:
+#ifdef ENODATA
+            return -ENODATA;
+#else
+            return -ENOENT;
+#endif
+            break;
+        /* Sometimes fuse returns a garbage file handle pointer to us... */
+        case EXT2_ET_MAGIC_EXT2_FILE:
+            return -EFAULT;
+
+        case EXT2_ET_UNIMPLEMENTED:
+            return -EOPNOTSUPP;
+
+        case EXT2_ET_FILE_RO:
+            return -EACCES;
+    }
+
+    // unclassified extfs error
+    if (fs) {
+        ext2fs_mark_super_dirty(fs);
+        ext2fs_flush(fs);
+    }
+    // decode error message
+    switch (err) {
+        case EXT2_ET_DIR_NO_SPACE:
+            err_msg = "EXT2_ET_DIR_NO_SPACE";
+            return -ENOSPC;
+
+        case EXT2_ET_BAD_MAGIC:
+            err_msg = "EXT2_ET_BAD_MAGIC";
+            return -EIO;
+
+        case EXT2_ET_DIR_CORRUPTED:
+            err_msg = "EXT2_ET_DIR_CORRUPTED";
+            return -EIO;
+
+        case EXT2_ET_UNEXPECTED_BLOCK_SIZE:
+            err_msg = "EXT2_ET_UNEXPECTED_BLOCK_SIZE";
+            return -EIO;
+
+        default:
+            err_msg = "to be decode";
+            return -EIO;
+    }
+}
+
+struct update_dotdot {
+    ext2_ino_t new_dotdot;
+};
+
+int update_dotdot_helper(
+    ext2_ino_t dir,
+    int entry,
+    struct ext2_dir_entry *dirent,
+    int offset,
+    int blocksize,
+    char *buf,
+    void *priv_data) {
+    struct update_dotdot *ud = (struct update_dotdot *)priv_data;
+
+    if (ext2fs_dirent_name_len(dirent) == 2 &&
+        dirent->name[0] == '.' && dirent->name[1] == '.') {
+        dirent->inode = ud->new_dotdot;
+        return DIRENT_CHANGED | DIRENT_ABORT;
+    }
+
+    return 0;
+}
+
+ext2_ino_t get_parent_dir_ino(ext2_filsys fs, const char *path) {
+    char *last_slash = strrchr((char *)path, '/');
+    if (last_slash == 0) {
+        return 0;
+    }
+    unsigned int parent_len = last_slash - path;
+    if (parent_len == 0) {
+        return EXT2_ROOT_INO;
+    }
+    char *parent_path = strndup(path, parent_len);
+    ext2_ino_t parent_ino = string_to_inode(fs, parent_path, 0);
+    LOG_DEBUG(VALUE(path), VALUE(parent_path), VALUE(parent_ino));
+    free(parent_path);
+    return parent_ino;
+}
+
+char *get_filename(const char *path) {
+    char *last_slash = strrchr((char *)path, (int)'/');
+    if (last_slash == nullptr) {
+        return nullptr;
+    }
+    char *filename = last_slash + 1;
+    if (strlen(filename) == 0) {
+        return nullptr;
+    }
+    return filename;
+}
+
+int create_file(ext2_filsys fs, const char *path, unsigned int mode, ext2_ino_t *ino) {
+    ext2_ino_t parent;
+    errcode_t ret = 0;
+
+    DEFER(LOG_DEBUG("create ", VALUE(path), VALUE(parent), VALUE(*ino), VALUE(ret)));
+    parent = get_parent_dir_ino(fs, path);
+    if (parent == 0) {
+        ret = ENOTDIR;
+        return -ENOTDIR;
+    }
+    ret = ext2fs_new_inode(fs, parent, mode, 0, ino);
+    if (ret) {
+        return parse_extfs_error(fs, parent, ret);
+    }
+    char *filename = get_filename(path);
+    if (filename == nullptr) {
+        // This should never happen.
+        ret = EISDIR;
+        return -EISDIR;
+    }
+    ret = ext2fs_link(fs, parent, filename, *ino, EXT2_FT_REG_FILE);
+    if (ret == EXT2_ET_DIR_NO_SPACE) {
+        ret = ext2fs_expand_dir(fs, parent);
+        if (ret) return parse_extfs_error(fs, parent, ret);
+        ret = ext2fs_link(fs, parent, filename, *ino, EXT2_FT_REG_FILE);
+    }
+    if (ret) return parse_extfs_error(fs, parent, ret);
+    if (ext2fs_test_inode_bitmap2(fs->inode_map, *ino)) {
+        LOG_WARN("inode already set ", VALUE(*ino));
+    }
+    ext2fs_inode_alloc_stats2(fs, *ino, +1, 0);
+
+    struct ext2_inode inode;
+    memset(&inode, 0, sizeof(inode));
+    inode.i_mode = (mode & ~LINUX_S_IFMT) | LINUX_S_IFREG;
+    inode.i_atime = inode.i_ctime = inode.i_mtime = time(0);
+    inode.i_links_count = 1;
+    ret = ext2fs_inode_size_set(fs, &inode, 0);  // TODO: update size? also on write?
+    if (ret) return parse_extfs_error(fs, 0, ret);
+    if (ext2fs_has_feature_inline_data(fs->super)) {
+        inode.i_flags |= EXT4_INLINE_DATA_FL;
+    } else if (ext2fs_has_feature_extents(fs->super)) {
+        ext2_extent_handle_t handle;
+        inode.i_flags &= ~EXT4_EXTENTS_FL;
+        ret = ext2fs_extent_open2(fs, *ino, &inode, &handle);
+        if (ret) return parse_extfs_error(fs, 0, ret);
+        ext2fs_extent_free(handle);
+    }
+    ret = ext2fs_write_new_inode(fs, *ino, &inode);
+    if (ret) return parse_extfs_error(fs, 0, ret);
+    if (inode.i_flags & EXT4_INLINE_DATA_FL) {
+        ret = ext2fs_inline_data_init(fs, *ino);
+        if (ret) return parse_extfs_error(fs, 0, ret);
+    }
+    return 0;
+}
+
+unsigned char ext2_file_type_to_d_type(int type) {
+    switch (type) {
+        case EXT2_FT_UNKNOWN:
+            return DT_UNKNOWN;
+        case EXT2_FT_REG_FILE:
+            return DT_REG;
+        case EXT2_FT_DIR:
+            return DT_DIR;
+        case EXT2_FT_CHRDEV:
+            return DT_CHR;
+        case EXT2_FT_BLKDEV:
+            return DT_BLK;
+        case EXT2_FT_FIFO:
+            return DT_FIFO;
+        case EXT2_FT_SOCK:
+            return DT_SOCK;
+        case EXT2_FT_SYMLINK:
+            return DT_LNK;
+        default:
+            return DT_UNKNOWN;
+    }
+}
+
+int array_push_dirent(std::vector<dirent> *dirs, struct ext2_dir_entry *dir, size_t len) {
+    struct dirent tmpdir;
+    tmpdir.d_ino = (ino_t)dir->inode;
+    tmpdir.d_off = 0;  // ?
+    tmpdir.d_reclen = dir->rec_len;
+    tmpdir.d_type = ext2_file_type_to_d_type(ext2fs_dirent_file_type(dir));
+    memset(tmpdir.d_name, 0, sizeof(tmpdir.d_name));
+    memcpy(tmpdir.d_name, dir->name, len);
+    dirs->emplace_back(tmpdir);
+    LOG_DEBUG(VALUE(tmpdir.d_ino), VALUE(tmpdir.d_reclen), VALUE(tmpdir.d_type), VALUE(tmpdir.d_name), VALUE(len));
+    return 0;
+}
+
+int copy_dirent_to_result(struct ext2_dir_entry *dirent, int offset, int blocksize, char *buf, void *priv_data) {
+    size_t len = ext2fs_dirent_name_len(dirent);
+    if ((strncmp(dirent->name, ".", len) != 0) &&
+        (strncmp(dirent->name, "..", len) != 0)) {
+        array_push_dirent((std::vector<::dirent> *)priv_data, dirent, len);
+    }
+    return 0;
+}
+
+blkcnt_t blocks_from_inode(ext2_filsys fs, struct ext2_inode *inode) {
+    blk64_t	ret = inode->i_blocks;
+
+	if (ext2fs_has_feature_huge_file(fs->super)) {
+		ret += ((long long) inode->osd2.linux2.l_i_blocks_hi) << 32;
+		if (inode->i_flags & EXT4_HUGE_FILE_FL)
+			ret *= (fs->blocksize / 512);
+	}
+	return ret;
+}

--- a/src/overlaybd/extfs/test/CMakeLists.txt
+++ b/src/overlaybd/extfs/test/CMakeLists.txt
@@ -1,0 +1,14 @@
+include_directories($ENV{GFLAGS}/include)
+link_directories($ENV{GFLAGS}/lib)
+
+include_directories($ENV{GTEST}/googletest/include)
+link_directories($ENV{GTEST}/lib)
+
+add_executable(extfs_test test.cpp)
+target_include_directories(extfs_test PUBLIC ${PHOTON_INCLUDE_DIR})
+target_link_libraries(extfs_test gtest gtest_main gflags pthread photon_static overlaybd_lib)
+
+add_test(
+    NAME extfs_test
+    COMMAND ${EXECUTABLE_OUTPUT_PATH}/extfs_test
+)

--- a/src/overlaybd/extfs/test/test.cpp
+++ b/src/overlaybd/extfs/test/test.cpp
@@ -1,0 +1,656 @@
+/*
+   Copyright The Overlaybd Authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+#include "../extfs.h"
+#include <fcntl.h>
+#include <dirent.h>
+#include <utime.h>
+#include <sys/sysmacros.h>
+#include <sys/time.h>
+#include <photon/photon.h>
+#include <photon/fs/localfs.h>
+#include <photon/fs/path.h>
+#include <photon/common/alog.h>
+#include <photon/common/alog-stdstring.h>
+#include <photon/common/enumerable.h>
+#include <gtest/gtest.h>
+
+#define FILE_SIZE (2 * 1024 * 1024)
+
+void print_stat(const char *path, struct stat *st) {
+    printf("File: %s\n", path);
+    printf("Size: %d, Blocks: %d, IO Blocks: %d, Type: %d\n", st->st_size, st->st_blocks, st->st_blksize, IFTODT(st->st_mode));
+    printf("Device: %u/%u, Inode: %d, Links: %d, Device type: %u,%u\n",
+           major(st->st_dev), minor(st->st_dev), st->st_ino, st->st_nlink, major(st->st_rdev), minor(st->st_rdev));
+    printf("Access: %05o, Uid: %d, Gid: %d\n", st->st_mode & 0xFFF, st->st_uid, st->st_gid);
+    printf("Access: %s", asctime(localtime(&(st->st_atim.tv_sec))));
+    printf("Modify: %s", asctime(localtime(&(st->st_mtim.tv_sec))));
+    printf("Change: %s", asctime(localtime(&(st->st_ctim.tv_sec))));
+}
+
+photon::fs::IFile *new_file(photon::fs::IFileSystem *fs, const char *path) {
+    auto file = fs->open(path, O_WRONLY | O_CREAT | O_TRUNC, 0755);
+    if (!file) {
+        LOG_ERRNO_RETURN(0, nullptr, "failed open file ", VALUE(path));
+    }
+    return file;
+}
+
+int write_file(photon::fs::IFile *file) {
+    std::string bb = "abcdefghijklmnopqrstuvwxyz0123456789abcdefghijklmnopqrstuvwxyz01";
+    std::string aa;
+    while (aa.size() < FILE_SIZE)
+        aa.append(bb);
+    auto ret = file->pwrite(aa.data(), aa.size(), 0);
+    if (ret != aa.size()) {
+        LOG_ERRNO_RETURN(0, -1, "failed write file ", VALUE(aa.size()), VALUE(ret))
+    }
+    LOG_DEBUG("write ` byte", ret);
+    return 0;
+}
+
+int stat(photon::fs::IFileSystem *fs, const char *path, struct stat *buf) {
+    auto ret = fs->stat(path, buf);
+    if (ret) {
+        LOG_ERRNO_RETURN(0, ret, "failed stat ", VALUE(path));
+    }
+    return 0;
+}
+
+int lstat(photon::fs::IFileSystem *fs, const char *path, struct stat *buf) {
+    auto ret = fs->lstat(path, buf);
+    if (ret) {
+        LOG_ERRNO_RETURN(0, ret, "failed lstat ", VALUE(path));
+    }
+    return 0;
+}
+
+int mkdir(photon::fs::IFileSystem *fs, const char *path) {
+    auto ret = fs->mkdir(path, 0755);
+    if (ret) {
+        LOG_ERRNO_RETURN(0, ret, "failed mkdir ", VALUE(path));
+    }
+    return 0;
+}
+
+int rmdir(photon::fs::IFileSystem *fs, const char *path) {
+    auto ret = fs->rmdir(path);
+    if (ret) {
+        LOG_ERRNO_RETURN(0, ret, "failed rmdir ", VALUE(path));
+    }
+    return 0;
+}
+
+int rename(photon::fs::IFileSystem *fs, const char *oldname, const char *newname) {
+    auto ret = fs->rename(oldname, newname);
+    if (ret) {
+        LOG_ERRNO_RETURN(0, ret, "failed rename ", VALUE(oldname), VALUE(newname));
+    }
+    return 0;
+}
+
+int chmod(photon::fs::IFileSystem *fs, const char *path, mode_t mode) {
+    auto ret = fs->chmod(path, mode);
+    if (ret) {
+        LOG_ERRNO_RETURN(0, ret, "failed chmod ", VALUE(path), VALUE(mode));
+    }
+    return 0;
+}
+
+int chown(photon::fs::IFileSystem *fs, const char *path, uid_t owner, gid_t group) {
+    auto ret = fs->chown(path, owner, group);
+    if (ret) {
+        LOG_ERRNO_RETURN(0, ret, "failed chown ", VALUE(path), VALUE(owner), VALUE(group));
+    }
+    return 0;
+}
+
+int lchown(photon::fs::IFileSystem *fs, const char *path, uid_t owner, gid_t group) {
+    auto ret = fs->lchown(path, owner, group);
+    if (ret) {
+        LOG_ERRNO_RETURN(0, ret, "failed lchown ", VALUE(path), VALUE(owner), VALUE(group));
+    }
+    return 0;
+}
+
+int link(photon::fs::IFileSystem *fs, const char *oldname, const char *newname) {
+    auto ret = fs->link(oldname, newname);
+    if (ret) {
+        LOG_ERRNO_RETURN(0, ret, "failed link ", VALUE(oldname), VALUE(newname));
+    }
+    return 0;
+}
+
+int symlink(photon::fs::IFileSystem *fs, const char *oldname, const char *newname) {
+    auto ret = fs->symlink(oldname, newname);
+    if (ret) {
+        LOG_ERRNO_RETURN(0, ret, "failed symlink ", VALUE(oldname), VALUE(newname));
+    }
+    return 0;
+}
+
+int unlink(photon::fs::IFileSystem *fs, const char *path) {
+    auto ret = fs->unlink(path);
+    if (ret) {
+        LOG_ERRNO_RETURN(0, ret, "failed unlink ", VALUE(path));
+    }
+    return 0;
+}
+
+int mknod(photon::fs::IFileSystem *fs, const char *path, mode_t mode, dev_t dev) {
+    auto ret = fs->mknod(path, mode, dev);
+    if (ret) {
+        LOG_ERRNO_RETURN(0, ret, "failed mknod ", VALUE(path), VALUE(mode), VALUE(dev));
+    }
+    return 0;
+}
+
+int utime(photon::fs::IFileSystem *fs, const char *path, const struct utimbuf *file_times) {
+    auto ret = fs->utime(path, file_times);
+    if (ret) {
+        LOG_ERRNO_RETURN(0, ret, "failed utime ", VALUE(path));
+    }
+    return 0;
+}
+
+int utimes(photon::fs::IFileSystem *fs, const char *path, const struct timeval tv[2]) {
+    auto ret = fs->utimes(path, tv);
+    if (ret) {
+        LOG_ERRNO_RETURN(0, ret, "failed utimes ", VALUE(path));
+    }
+    return 0;
+}
+
+int lutimes(photon::fs::IFileSystem *fs, const char *path, const struct timeval tv[2]) {
+    auto ret = fs->lutimes(path, tv);
+    if (ret) {
+        LOG_ERRNO_RETURN(0, ret, "failed utimes ", VALUE(path));
+    }
+    return 0;
+}
+
+int opendir(photon::fs::IFileSystem *fs, const char *path) {
+    auto ret = fs->opendir(path);
+    if (ret == nullptr) {
+        LOG_ERRNO_RETURN(0, -1, "failed opendir ", VALUE(path));
+    } else {
+        delete ret;
+        return 0;
+    }
+}
+
+int walkdir(photon::fs::IFileSystem *fs, const char *path) {
+    struct stat buf;
+    if (fs->lstat(path, &buf) < 0) {
+        LOG_ERRNO_RETURN(0, -1, "failed to lstat ", VALUE(path));
+    }
+    LOG_DEBUG("walk dir ", VALUE(path));
+    int count = 0;
+    for (auto file : enumerable(photon::fs::Walker(fs, path))) {
+        auto fn = std::string(file);
+        LOG_DEBUG(VALUE(fn));
+        count++;
+    }
+    return count;
+}
+
+int remove_all(photon::fs::IFileSystem *fs, const std::string &path) {
+    if (fs == nullptr || path.empty()) {
+        LOG_ERROR("remove_all ` failed, fs is null or path is empty", path);
+        return -1;
+    }
+    struct stat statBuf;
+    int ret = 0;
+    if (fs->lstat(path.c_str(), &statBuf) == 0) {  // get stat
+        if (S_ISDIR(statBuf.st_mode) == 0) {       // not dir
+            return fs->unlink(path.c_str());
+        }
+    } else {
+        LOG_ERRNO_RETURN(0, -1, "get path ` stat failed", path);
+    }
+
+    auto dirs = fs->opendir(path.c_str());
+    if (dirs == nullptr) {
+        LOG_ERRNO_RETURN(0, -1, "open dir ` failed", path);
+    }
+    dirent *dirInfo;
+    while ((dirInfo = dirs->get()) != nullptr) {
+        if (strcmp(dirInfo->d_name, ".") != 0 && strcmp(dirInfo->d_name, "..") != 0) {
+            std::string npath(path);
+            if (npath.back() == '/') {
+                npath = npath.substr(0, npath.size() - 1);
+            }
+            LOG_DEBUG(VALUE(path), VALUE(npath));
+            ret = remove_all(fs, npath + "/" + dirInfo->d_name);
+            if (ret) return ret;
+        }
+        dirs->next();
+    }
+
+    fs->closedir(dirs);
+    if (path == "/")
+        return 0;
+    ret = fs->rmdir(path.c_str());
+    if (ret) return ret;
+
+    return 0;
+}
+
+photon::fs::IFileSystem *init_extfs() {
+    std::string rootfs = "/tmp/rootfs.img";
+    // mkfs
+    std::string cmd = "mkfs.ext4 -F -b 4096 " + rootfs + " 100M";
+    auto ret = system(cmd.c_str());
+    if (ret != 0) {
+        LOG_ERRNO_RETURN(0, nullptr, "failed mkfs");
+    }
+
+    // new extfs
+    auto image_file = photon::fs::open_localfile_adaptor(rootfs.c_str(), O_RDWR, 0644, 0);
+    if (!image_file) {
+        LOG_ERRNO_RETURN(0, nullptr, "failed to open `", rootfs);
+    }
+    photon::fs::IFileSystem *extfs = new_extfs(image_file);
+    if (!extfs) {
+        delete image_file;
+        LOG_ERRNO_RETURN(0, nullptr, "failed open fs");
+    }
+
+    return extfs;
+}
+class ExtfsTest : public ::testing::Test {
+   protected:
+    virtual void SetUp() override {
+    }
+    virtual void TearDown() override {
+    }
+
+    static void SetUpTestSuite() {
+        fs = init_extfs();
+        ASSERT_NE(nullptr, fs);
+    }
+
+    static void TearDownTestSuite() {
+        if (fs)
+            delete fs;
+    }
+
+    static photon::fs::IFileSystem *fs;
+};
+
+photon::fs::IFileSystem *ExtfsTest::fs = nullptr;
+
+TEST_F(ExtfsTest, Regfile) {
+    photon::fs::IFile *file = new_file(fs, "/file1");
+    ASSERT_NE(nullptr, file);
+
+    auto ret = write_file(file);
+    ASSERT_EQ(0, ret);
+
+    char buf[16];
+    ret = file->pread(buf, 16, 0);
+    EXPECT_EQ(16, ret);
+    EXPECT_EQ(0, memcmp(buf, "abcdefghijklmnop", 16));
+    ret = file->pread(buf, 16, 16384);
+    EXPECT_EQ(16, ret);
+    EXPECT_EQ(0, memcmp(buf, "abcdefghijklmnop", 16));
+    delete file;
+    // stat
+    struct stat st;
+    ret = stat(fs, "/file1", &st);
+    EXPECT_EQ(0, ret);
+    EXPECT_EQ(FILE_SIZE, st.st_size);
+    EXPECT_EQ(DT_REG, IFTODT(st.st_mode));
+}
+
+TEST_F(ExtfsTest, Dir) {
+    // mkdir
+    auto ret = mkdir(fs, "/dir1");
+    EXPECT_EQ(0, ret);
+    struct stat st;
+    ret = stat(fs, "/dir1", &st);
+    EXPECT_EQ(0, ret);
+    EXPECT_EQ(DT_DIR, IFTODT(st.st_mode));
+
+    ret = mkdir(fs, "/dir1/subdir1");
+    EXPECT_EQ(0, ret);
+    ret = mkdir(fs, "/dir1");
+    EXPECT_EQ(-1, ret);
+    EXPECT_EQ(EEXIST, errno);
+    ret = mkdir(fs, "/dir2/dir2");
+    EXPECT_EQ(-1, ret);
+    EXPECT_EQ(ENOTDIR, errno);
+    // rmdir
+    ret = mkdir(fs, "/dir2");
+    EXPECT_EQ(0, ret);
+    ret = stat(fs, "/dir2", &st);
+    EXPECT_EQ(0, ret);
+    EXPECT_EQ(DT_DIR, IFTODT(st.st_mode));
+    ret = rmdir(fs, "/dir2");
+    EXPECT_EQ(0, ret);
+    ret = stat(fs, "/dir2", &st);
+    EXPECT_EQ(-1, ret);
+    EXPECT_EQ(ENOENT, errno);
+    ret = rmdir(fs, "/dir1");
+    EXPECT_EQ(-1, ret);
+    EXPECT_EQ(ENOTEMPTY, errno);
+}
+
+TEST_F(ExtfsTest, Link) {
+    auto ret = link(fs, "/file1", "/dir1/file1_link");
+    EXPECT_EQ(0, ret);
+    struct stat st;
+    ret = stat(fs, "/dir1/file1_link", &st);
+    EXPECT_EQ(0, ret);
+    EXPECT_EQ(DT_REG, IFTODT(st.st_mode));
+    EXPECT_EQ(2, st.st_nlink);
+
+    ret = symlink(fs, "/file1", "/dir1/file1_symlink");
+    EXPECT_EQ(0, ret);
+    ret = stat(fs, "/dir1/file1_symlink", &st);
+    EXPECT_EQ(0, ret);
+    EXPECT_EQ(DT_REG, IFTODT(st.st_mode));
+    ret = lstat(fs, "/dir1/file1_symlink", &st);
+    EXPECT_EQ(0, ret);
+    EXPECT_EQ(DT_LNK, IFTODT(st.st_mode));
+
+    ret = link(fs, "/dir1/file1_symlink", "/file1_link");
+    EXPECT_EQ(0, ret);
+    ret = stat(fs, "/file1_link", &st);
+    EXPECT_EQ(0, ret);
+    EXPECT_EQ(DT_REG, IFTODT(st.st_mode));
+    ret = lstat(fs, "/file1_link", &st);
+    EXPECT_EQ(0, ret);
+    EXPECT_EQ(DT_LNK, IFTODT(st.st_mode));
+
+    ret = symlink(fs, "../file2", "/dir1/file2_symlink");
+    EXPECT_EQ(0, ret);
+    ret = stat(fs, "/dir1/file2_symlink", &st);
+    EXPECT_EQ(-1, ret);
+    EXPECT_EQ(ENOENT, errno);
+    ret = lstat(fs, "/dir1/file2_symlink", &st);
+    EXPECT_EQ(0, ret);
+    EXPECT_EQ(DT_LNK, IFTODT(st.st_mode));
+
+    ret = symlink(fs, "/file2", "/dir1/file1_symlink");
+    EXPECT_EQ(-1, ret);
+    EXPECT_EQ(EEXIST, errno);
+    ret = symlink(fs, "/file1", "/dir2/file1_symlink");
+    EXPECT_EQ(-1, ret);
+    EXPECT_EQ(ENOTDIR, errno);
+    ret = symlink(fs, "..//file1", "/dir1/file5_symlink");
+    EXPECT_EQ(0, ret);
+    ret = lstat(fs, "/dir1/file5_symlink", &st);
+    EXPECT_EQ(0, ret);
+    ret = stat(fs, "/dir1/file5_symlink", &st);
+    EXPECT_EQ(-1, ret);
+    EXPECT_EQ(ENOENT, errno);
+}
+
+TEST_F(ExtfsTest, Unlink) {
+    auto ret = symlink(fs, "/file2", "/dir1/file3_symlink");
+    EXPECT_EQ(0, ret);
+    struct stat st;
+    ret = lstat(fs, "/dir1/file3_symlink", &st);
+    EXPECT_EQ(0, ret);
+    ret = unlink(fs, "/dir1/file3_symlink");
+    EXPECT_EQ(0, ret);
+    ret = lstat(fs, "/dir1/file3_symlink", &st);
+    EXPECT_EQ(-1, ret);
+    EXPECT_EQ(ENOENT, errno);
+
+    ret = unlink(fs, "/dir1/file6_symlink");
+    EXPECT_EQ(-1, ret);
+    EXPECT_EQ(ENOENT, errno);
+    ret = unlink(fs, "/dir1");
+    EXPECT_EQ(-1, ret);
+    EXPECT_EQ(EISDIR, errno);
+}
+
+TEST_F(ExtfsTest, Chmod) {
+    auto ret = chmod(fs, "/file1", 0700);
+    EXPECT_EQ(0, ret);
+    struct stat st;
+    ret = lstat(fs, "/file1", &st);
+    EXPECT_EQ(0, ret);
+    EXPECT_EQ(0700, st.st_mode & 0xFFF);
+
+    ret = chmod(fs, "/dir1", 0777);
+    EXPECT_EQ(0, ret);
+    ret = stat(fs, "/dir1", &st);
+    EXPECT_EQ(0, ret);
+    EXPECT_EQ(0777, st.st_mode & 0xFFF);
+
+    ret = chmod(fs, "/file2", 0777);
+    EXPECT_EQ(-1, ret);
+    EXPECT_EQ(ENOENT, errno);
+}
+
+TEST_F(ExtfsTest, Chown) {
+    auto ret = chown(fs, "/dir1", 1001, 1010);
+    EXPECT_EQ(0, ret);
+    struct stat st;
+    ret = stat(fs, "/dir1", &st);
+    EXPECT_EQ(0, ret);
+    EXPECT_EQ(1001, st.st_uid);
+    EXPECT_EQ(1010, st.st_gid);
+
+    ret = chown(fs, "/dir1/file1_symlink", 1002, 1020);
+    EXPECT_EQ(0, ret);
+    ret = stat(fs, "/dir1/file1_symlink", &st);
+    EXPECT_EQ(0, ret);
+    EXPECT_EQ(1002, st.st_uid);
+    EXPECT_EQ(1020, st.st_gid);
+
+    ret = chown(fs, "/dir1/file2_symlink", 1003, 1030);
+    EXPECT_EQ(-1, ret);
+    EXPECT_EQ(ENOENT, errno);
+    auto file = new_file(fs, "/file2");
+    EXPECT_NE(nullptr, file);
+    DEFER(delete file;);
+
+    struct stat st_old;
+    ret = stat(fs, "/dir1/file2_symlink", &st_old);
+    EXPECT_EQ(0, ret);
+    ret = lchown(fs, "/dir1/file2_symlink", 1003, 1030);
+    EXPECT_EQ(0, ret);
+    ret = lstat(fs, "/dir1/file2_symlink", &st);
+    EXPECT_EQ(0, ret);
+    EXPECT_EQ(1003, st.st_uid);
+    EXPECT_EQ(1030, st.st_gid);
+    ret = stat(fs, "/dir1/file2_symlink", &st);
+    EXPECT_EQ(0, ret);
+    EXPECT_EQ(st_old.st_uid, st.st_uid);
+    EXPECT_EQ(st_old.st_gid, st.st_gid);
+    ret = chown(fs, "/dir1/file2_symlink", 1004, 1040);
+    EXPECT_EQ(0, ret);
+    ret = stat(fs, "/dir1/file2_symlink", &st);
+    EXPECT_EQ(0, ret);
+    EXPECT_EQ(1004, st.st_uid);
+    EXPECT_EQ(1040, st.st_gid);
+    EXPECT_NE(st_old.st_uid, st.st_uid);
+    EXPECT_NE(st_old.st_gid, st.st_gid);
+    ret = unlink(fs, "/file2");
+    EXPECT_EQ(0, ret);
+}
+
+TEST_F(ExtfsTest, Mknod) {
+    auto ret = mkdir(fs, "/dev");
+    EXPECT_EQ(0, ret);
+    ret = mknod(fs, "/dev/blkdev", 0755 | S_IFBLK, makedev(240, 0));
+    EXPECT_EQ(0, ret);
+    struct stat st;
+    ret = stat(fs, "/dev/blkdev", &st);
+    EXPECT_EQ(0, ret);
+    EXPECT_EQ(DT_BLK, IFTODT(st.st_mode));
+
+    ret = mknod(fs, "/dev/chardev", 0700 | S_IFCHR, makedev(42, 0));
+    EXPECT_EQ(0, ret);
+    ret = lstat(fs, "/dev/chardev", &st);
+    EXPECT_EQ(0, ret);
+    EXPECT_EQ(DT_CHR, IFTODT(st.st_mode));
+
+    ret = mknod(fs, "/fifo", S_IFIFO, makedev(0, 0));
+    EXPECT_EQ(0, ret);
+    ret = lstat(fs, "/fifo", &st);
+    EXPECT_EQ(0, ret);
+    EXPECT_EQ(DT_FIFO, IFTODT(st.st_mode));
+
+    ret = mknod(fs, "/dev2/blkdev", 0755 | S_IFBLK, makedev(240, 0));
+    EXPECT_EQ(-1, ret);
+    EXPECT_EQ(ENOTDIR, errno);
+    ret = mknod(fs, "/dev/blkdev", 0755 | S_IFBLK, makedev(240, 0));
+    EXPECT_EQ(-1, ret);
+    EXPECT_EQ(EEXIST, errno);
+}
+
+TEST_F(ExtfsTest, Utime) {
+    struct timeval tv[2];
+    gettimeofday(&tv[0], nullptr);
+    gettimeofday(&tv[1], nullptr);
+
+    struct stat st, lst, st_old, lst_old;
+    auto ret = lstat(fs, "/dir1/file1_symlink", &lst_old);
+    EXPECT_EQ(0, ret);
+    tv[0].tv_sec = tv[0].tv_sec - 3661;
+    ret = utimes(fs, "/dir1/file1_symlink", tv);
+    EXPECT_EQ(0, ret);
+    ret = stat(fs, "/dir1/file1_symlink", &st);
+    EXPECT_EQ(0, ret);
+    EXPECT_EQ(tv[0].tv_sec, st.st_atim.tv_sec);
+    EXPECT_EQ(tv[1].tv_sec, st.st_mtim.tv_sec);
+    ret = lstat(fs, "/dir1/file1_symlink", &lst);
+    EXPECT_EQ(0, ret);
+    EXPECT_EQ(lst_old.st_atim.tv_sec, lst.st_atim.tv_sec);
+    EXPECT_EQ(lst_old.st_mtim.tv_sec, lst.st_mtim.tv_sec);
+
+    ret = stat(fs, "/dir1/file1_symlink", &st_old);
+    EXPECT_EQ(0, ret);
+    tv[1].tv_sec = tv[1].tv_sec - 3661;
+    ret = lutimes(fs, "/dir1/file1_symlink", tv);
+    EXPECT_EQ(0, ret);
+    ret = stat(fs, "/dir1/file1_symlink", &st);
+    EXPECT_EQ(0, ret);
+    EXPECT_EQ(st_old.st_atim.tv_sec, st.st_atim.tv_sec);
+    EXPECT_EQ(st_old.st_mtim.tv_sec, st.st_mtim.tv_sec);
+    ret = lstat(fs, "/dir1/file1_symlink", &lst);
+    EXPECT_EQ(0, ret);
+    EXPECT_EQ(tv[0].tv_sec, lst.st_atim.tv_sec);
+    EXPECT_EQ(tv[1].tv_sec, lst.st_mtim.tv_sec);
+
+    struct utimbuf ut;
+    ut.actime = tv[0].tv_sec - 3661;
+    ut.modtime = tv[1].tv_sec - 3661;
+    ret = lstat(fs, "/dir1/file1_symlink", &lst_old);
+    EXPECT_EQ(0, ret);
+    ret = utime(fs, "/dir1/file1_symlink", &ut);
+    EXPECT_EQ(0, ret);
+    ret = stat(fs, "/dir1/file1_symlink", &st);
+    EXPECT_EQ(0, ret);
+    EXPECT_EQ(ut.actime, st.st_atim.tv_sec);
+    EXPECT_EQ(ut.modtime, st.st_mtim.tv_sec);
+    ret = lstat(fs, "/dir1/file1_symlink", &lst);
+    EXPECT_EQ(0, ret);
+    EXPECT_EQ(lst_old.st_atim.tv_sec, lst.st_atim.tv_sec);
+    EXPECT_EQ(lst_old.st_mtim.tv_sec, lst.st_mtim.tv_sec);
+
+    ret = utimes(fs, "/dir1/file2_symlink", tv);
+    EXPECT_EQ(-1, ret);
+    EXPECT_EQ(ENOENT, errno);
+    ret = lutimes(fs, "/dir3/file1_symlink", tv);
+    EXPECT_EQ(-1, ret);
+    EXPECT_EQ(ENOENT, errno);
+    ret = lutimes(fs, "/dir1/file2_symlink", tv);
+    EXPECT_EQ(0, ret);
+    ret = utime(fs, "/dir1/file2_symlink", &ut);
+    EXPECT_EQ(-1, ret);
+    EXPECT_EQ(ENOENT, errno);
+}
+
+TEST_F(ExtfsTest, Rename) {
+    struct stat st;
+    auto ret = stat(fs, "/file2", &st);
+    EXPECT_EQ(-1, ret);
+    EXPECT_EQ(ENOENT, errno);
+    ret = rename(fs, "/file1", "/file2");
+    EXPECT_EQ(0, ret);
+    ret = stat(fs, "/file1", &st);
+    EXPECT_EQ(-1, ret);
+    EXPECT_EQ(ENOENT, errno);
+    ret = stat(fs, "/file2", &st);
+    EXPECT_EQ(0, ret);
+
+    ret = rename(fs, "/file2", "/dir1");
+    EXPECT_EQ(-1, ret);
+    EXPECT_EQ(ENOTEMPTY, errno);
+    ret = rename(fs, "/dir1", "/dir2");
+    EXPECT_EQ(0, ret);
+    ret = rename(fs, "/file2", "/dir2/file2");
+    EXPECT_EQ(0, ret);
+    ret = rename(fs, "/file2", "/dir2/file2");
+    EXPECT_EQ(-1, ret);
+    EXPECT_EQ(ENOENT, errno);
+    ret = rename(fs, "/dir2/file2", "/dir1/file2");
+    EXPECT_EQ(-1, ret);
+    EXPECT_EQ(ENOTDIR, errno);
+    ret = rename(fs, "/dir2/file2", "/dir2/file1_link");
+    EXPECT_EQ(0, ret);
+    auto file = new_file(fs, "/file2");
+    EXPECT_NE(nullptr, file);
+    ret = rename(fs, "/file2", "/dir2/file2");
+    EXPECT_EQ(0, ret);
+    ret = rename(fs, "/dir2", "/dir1");
+    EXPECT_EQ(0, ret);
+}
+
+TEST_F(ExtfsTest, Readdir) {
+    auto ret = opendir(fs, "/dir3");
+    EXPECT_EQ(-1, ret);
+    EXPECT_EQ(ENOENT, errno);
+    ret = opendir(fs, "/");
+    EXPECT_EQ(0, ret);
+    ret = walkdir(fs, "/test");
+    EXPECT_EQ(-1, ret);
+    ret = walkdir(fs, "/dir1");
+    LOG_INFO("found ` file", ret);
+    EXPECT_LT(0, ret);
+    ret = walkdir(fs, "/");
+    LOG_INFO("found ` file", ret);
+    EXPECT_LT(0, ret);
+    // rm all
+    ret = remove_all(fs, "/test");
+    EXPECT_EQ(-1, ret);
+    ret = remove_all(fs, "/dir1");
+    EXPECT_EQ(0, ret);
+    ret = opendir(fs, "/dir1");
+    EXPECT_EQ(-1, ret);
+    EXPECT_EQ(ENOENT, errno);
+    ret = remove_all(fs, "/");
+    EXPECT_EQ(0, ret);
+    ret = walkdir(fs, "/");
+    LOG_INFO("found ` file", ret);
+    EXPECT_EQ(0, ret);
+}
+
+int main(int argc, char **argv) {
+    photon::init(photon::INIT_EVENT_DEFAULT, photon::INIT_IO_DEFAULT);
+    DEFER(photon::fini(););
+    set_log_output_level(1);
+
+    ::testing::InitGoogleTest(&argc, argv);
+    auto ret = RUN_ALL_TESTS();
+    if (ret) LOG_ERROR_RETURN(0, ret, VALUE(ret));
+}

--- a/src/tools/CMakeLists.txt
+++ b/src/tools/CMakeLists.txt
@@ -10,9 +10,16 @@ add_executable(overlaybd-zfile overlaybd-zfile.cpp)
 target_include_directories(overlaybd-zfile PUBLIC ${PHOTON_INCLUDE_DIR})
 target_link_libraries(overlaybd-zfile photon_static overlaybd_lib)
 
+add_executable(overlaybd-apply overlaybd-apply.cpp)
+target_include_directories(overlaybd-apply PUBLIC ${PHOTON_INCLUDE_DIR} ${rapidjson_SOURCE_DIR}/include)
+target_link_libraries(overlaybd-apply photon_static overlaybd_lib overlaybd_image_lib)
+
+set_target_properties(overlaybd-apply PROPERTIES INSTALL_RPATH "/opt/overlaybd/lib")
+
 install(TARGETS
     overlaybd-commit
     overlaybd-create
     overlaybd-zfile
+    overlaybd-apply
     DESTINATION /opt/overlaybd/bin
 )

--- a/src/tools/overlaybd-apply.cpp
+++ b/src/tools/overlaybd-apply.cpp
@@ -1,0 +1,95 @@
+/*
+   Copyright The Overlaybd Authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+#include <photon/common/alog.h>
+#include <photon/fs/localfs.h>
+#include <photon/fs/subfs.h>
+#include <photon/photon.h>
+#include "../overlaybd/lsmt/file.h"
+#include "../overlaybd/zfile/zfile.h"
+#include "../overlaybd/untar/libtar.h"
+#include "../overlaybd/extfs/extfs.h"
+#include <errno.h>
+#include <fcntl.h>
+#include <inttypes.h>
+#include <memory>
+#include <string>
+#include <stdio.h>
+#include <stdlib.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <unistd.h>
+#include "../image_service.h"
+#include "../image_file.h"
+#include "CLI11.hpp"
+
+using namespace std;
+using namespace photon::fs;
+
+IFile *open_file(const char *fn, int flags, mode_t mode = 0) {
+    auto file = open_localfile_adaptor(fn, flags, mode, 0);
+    if (!file) {
+        fprintf(stderr, "failed to open file '%s', %d: %s\n", fn, errno, strerror(errno));
+        exit(-1);
+    }
+    return file;
+}
+
+int main(int argc, char **argv) {
+    string commit_msg;
+    string parent_uuid;
+    std::string image_config_path, input_path;
+    bool compress_zfile = false;
+
+    CLI::App app{"this is overlaybd-apply, apply OCIv1 tar layer to overlaybd format"};
+    app.add_option("input_path", input_path, "input OCIv1 tar layer path")->type_name("FILEPATH")->check(CLI::ExistingFile)->required();
+    app.add_option("image_config_path", image_config_path, "overlaybd image config path")->type_name("FILEPATH")->check(CLI::ExistingFile)->required();
+    CLI11_PARSE(app, argc, argv);
+
+    set_log_output_level(1);
+    photon::init(photon::INIT_EVENT_DEFAULT, photon::INIT_IO_DEFAULT);
+
+    auto imgservice = create_image_service();
+    ImageFile *imgfile = imgservice->create_image_file(image_config_path.c_str());
+    if (imgfile == nullptr) {
+        fprintf(stderr, "failed to create image file\n");
+        exit(-1);
+    }
+    auto extfs = new_extfs(imgfile);
+    if (!extfs) {
+        fprintf(stderr, "new extfs failed, %s\n", strerror(errno));
+        exit(-1);
+    }
+    auto target = new_subfs(extfs, "/", true);
+    if (!target) {
+        fprintf(stderr, "new subfs failed, %s\n", strerror(errno));
+        exit(-1);
+    }
+
+    auto tarf = open_file(input_path.c_str(), O_RDONLY, 0666);
+    auto tar = new Tar(tarf, target, 0);
+    if (tar->extract_all() < 0) {
+        fprintf(stderr, "failed to extract\n");
+        exit(-1);
+    } else {
+        fprintf(stderr, "overlaybd-apply done\n");
+    }
+
+    delete target;
+    delete imgfile;
+
+    return 0;
+}


### PR DESCRIPTION
overlaybd-apply could be used with [accelerated-container-image](https://github.com/containerd/accelerated-container-image) to convert an image from traditional OCI tarball format to overlaybd format.

Co-authored-by: Lanzheng Liu <lanzheng.liulz@alibaba-inc.com>
Co-authored-by: Chen Chen <yuchen.cc@alibaba-inc.com>
Signed-off-by: Bowei Zhuang <zhuangbowei.zbw@alibaba-inc.com>