### PR TITLE
Add registryfs v2

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -52,6 +52,7 @@ jobs:
       shell: bash
       run: |
         sudo make install
+        sudo cp ${{github.workspace}}/src/example_config/overlaybd-registryv2.json /etc/overlaybd/overlaybd.json
         sudo systemctl enable /opt/overlaybd/overlaybd-tcmu.service
         sudo systemctl start overlaybd-tcmu
         sudo systemctl status overlaybd-tcmu

--- a/CMake/Findphoton.cmake
+++ b/CMake/Findphoton.cmake
@@ -4,7 +4,7 @@ set(FETCHCONTENT_QUIET false)
 FetchContent_Declare(
   photon
   GIT_REPOSITORY https://github.com/alibaba/PhotonLibOS.git
-  GIT_TAG v0.4.1
+  GIT_TAG v0.5.1
 )
 
 if(BUILD_TESTING)

--- a/CMake/Findrapidjson.cmake
+++ b/CMake/Findrapidjson.cmake
@@ -1,7 +1,7 @@
 FetchContent_Declare(
   rapidjson
   GIT_REPOSITORY https://github.com/Tencent/rapidjson.git
-  GIT_TAG master
+  GIT_TAG 80b6d1c83402a5785c486603c5611923159d0894
 )
 FetchContent_GetProperties(rapidjson)
 if (NOT rapidjson_POPULATED)

--- a/README.md
+++ b/README.md
@@ -153,6 +153,7 @@ credentialConfig.path | credential file path or url which is determined by `mode
 | download.maxMBps    | The speed limit in MB/s for a downloading task.                                                       |
 | enableAudit         | Enable audit or not.                                                                                  |
 | auditPath           | The path for audit file, `/var/log/overlaybd-audit.log` is the default value.                         |
+| registryFsVersion   | registry client version, 'v1' libcurl based, 'v2' is photon http based. 'v1' is the default value.    |
 
 > NOTE: `download` is the config for background downloading. After an overlaybd device is lauched, a background task will be running to fetch the whole blobs into local directories. After downloading, I/O requests are directed to local files. Unlike other options, download config is reloaded when a device launching.
 

--- a/src/config.h
+++ b/src/config.h
@@ -88,6 +88,7 @@ struct GlobalConfig : public ConfigUtils::Config {
     APPCFG_PARA(enableAudit, bool, true);
     APPCFG_PARA(p2pConfig, P2PConfig);
     APPCFG_PARA(auditPath, std::string, "/var/log/overlaybd-audit.log");
+    APPCFG_PARA(registryFsVersion, std::string, "v1");
 };
 
 struct AuthConfig : public ConfigUtils::Config {
@@ -101,6 +102,6 @@ struct ImageAuthResponse : public ConfigUtils::Config {
     APPCFG_PARA(traceId, std::string, "");
 	APPCFG_PARA(success, bool, false);
 	APPCFG_PARA(data, AuthConfig);
-}; 
+};
 
 } // namespace ImageConfigNS

--- a/src/example_config/overlaybd-registryv2.json
+++ b/src/example_config/overlaybd-registryv2.json
@@ -1,0 +1,23 @@
+{
+    "logLevel": 1,
+    "registryCacheDir": "/opt/overlaybd/registry_cache",
+    "registryCacheSizeGB": 4,
+    "credentialConfig": {
+        "mode": "file",
+        "path": "/opt/overlaybd/cred.json"
+    },
+    "ioEngine": 0,
+    "download": {
+        "enable": true,
+        "delay": 600,
+        "delayExtra": 30,
+        "maxMBps": 100
+    },
+    "p2pConfig": {
+        "enable": false,
+        "address": "localhost:9731/accelerator"
+    },
+    "enableAudit": true,
+    "auditPath": "/var/log/overlaybd-audit.log",
+    "registryFsVersion": "v2"
+}

--- a/src/image_file.h
+++ b/src/image_file.h
@@ -51,15 +51,12 @@ public:
     }
 
     ~ImageFile() {
-        delete m_file;
-        delete m_prefetcher;
-    }
-
-    int close() override {
         m_status = -1;
         if (dl_thread_jh != nullptr)
             photon::thread_join(dl_thread_jh);
-        return m_file->close();
+        delete m_prefetcher;
+        m_file->close();
+        delete m_file;
     }
 
     int fstat(struct stat *buf) override {

--- a/src/image_service.cpp
+++ b/src/image_service.cpp
@@ -276,9 +276,12 @@ int ImageService::init() {
             }
         }
 
-        LOG_INFO("create registryfs with cafile:`", cafile);
+        LOG_INFO("create registryfs with cafile:`, version:`", cafile, global_conf.registryFsVersion());
+        auto registryfs_creator = new_registryfs_v1;
+        if (global_conf.registryFsVersion() == "v2")
+            registryfs_creator = new_registryfs_v2;
 
-        auto registry_fs = new_registryfs_with_credential_callback(
+        auto registry_fs = registryfs_creator(
             {this, &ImageService::reload_auth}, cafile, 30UL * 1000000);
         if (registry_fs == nullptr) {
             LOG_ERROR_RETURN(0, -1, "create registryfs failed.");

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -327,7 +327,6 @@ static int close_cnt = 0;
 static void dev_close(struct tcmu_device *dev) {
     obd_dev *odev = (obd_dev *)tcmu_dev_get_private(dev);
     delete odev->loop;
-    odev->file->close();
     delete odev->file;
     delete odev;
     close_cnt++;

--- a/src/overlaybd/registryfs/registryfs.h
+++ b/src/overlaybd/registryfs/registryfs.h
@@ -28,8 +28,12 @@ public:
 using PasswordCB = Delegate<std::pair<std::string, std::string>, const char *>;
 
 extern "C" {
-photon::fs::IFileSystem *new_registryfs_with_credential_callback(PasswordCB callback,
-                                                     const char *caFile = nullptr,
-                                                     uint64_t timeout = -1);
+photon::fs::IFileSystem *new_registryfs_v1(PasswordCB callback,
+                                           const char *caFile = nullptr,
+                                           uint64_t timeout = -1);
+
+photon::fs::IFileSystem *new_registryfs_v2(PasswordCB callback,
+                                           const char *caFile = nullptr,
+                                           uint64_t timeout = -1);
 }
 

--- a/src/prefetch.cpp
+++ b/src/prefetch.cpp
@@ -94,8 +94,7 @@ public:
         }
 
         if (m_trace_file != nullptr) {
-            m_trace_file->close();
-            m_trace_file = nullptr;
+            safe_delete(m_trace_file);
         }
     }
 


### PR DESCRIPTION
registryfs v2 is based on photon http client instead of libcurl.
Add `registryFsVersion: "v2"` to /etc/overlaybd/overlaybd.json to enable it.