### PR TITLE
enable obd dev work in thread

### DIFF
--- a/src/config.h
+++ b/src/config.h
@@ -86,6 +86,7 @@ struct GlobalConfig : public ConfigUtils::Config {
     APPCFG_PARA(logPath, std::string, "/var/log/overlaybd.log");
     APPCFG_PARA(download, DownloadConfig);
     APPCFG_PARA(enableAudit, bool, true);
+    APPCFG_PARA(enableThread, bool, false);
     APPCFG_PARA(p2pConfig, P2PConfig);
     APPCFG_PARA(auditPath, std::string, "/var/log/overlaybd-audit.log");
     APPCFG_PARA(registryFsVersion, std::string, "v1");

--- a/src/image_service.cpp
+++ b/src/image_service.cpp
@@ -299,6 +299,9 @@ int ImageService::init() {
             global_fs.remote_fs = registry_fs;
             return 0;
         }
+        if (global_conf.enableThread() == true && global_conf.cacheType() == "file") {
+            LOG_ERROR_RETURN(0, -1, "multi-thread has not been valid for file cache");
+        }
         if (global_conf.cacheType() == "file") {
             auto registry_cache_fs = new_localfs_adaptor(
                 global_conf.registryCacheDir().c_str());
@@ -342,7 +345,7 @@ int ImageService::init() {
             }
             global_fs.media_file = media_file;
 
-            global_fs.remote_fs = FileSystem::new_ocf_cached_fs(tar_fs, namespace_fs, 65536, 0,
+            global_fs.remote_fs = FileSystem::new_ocf_cached_fs(tar_fs, namespace_fs, 65536, 262144,
                                                                 media_file, reload_media, io_alloc);
         }
 

--- a/src/overlaybd/cache/ocf_cache/ease_bindings/env/ocf_env.h
+++ b/src/overlaybd/cache/ocf_cache/ease_bindings/env/ocf_env.h
@@ -296,69 +296,59 @@ void env_completion_destroy(env_completion *completion);
 
 /* ATOMIC VARIABLES */
 typedef struct {
-    int counter;
+   volatile int counter;
 } env_atomic;
 
 typedef struct {
-    long counter;
+   volatile long counter;
 } env_atomic64;
 
 static inline int env_atomic_read(const env_atomic* a) {
-    return a->counter;
+    return a->counter; /* TODO */
 }
 
 static inline void env_atomic_set(env_atomic* a, int i) {
-    a->counter = i;
+    a->counter = i; /* TODO */
 }
 
 static inline void env_atomic_add(int i, env_atomic* a) {
-    a->counter += i;
+    __sync_add_and_fetch(&a->counter, i);
 }
 
 static inline void env_atomic_sub(int i, env_atomic* a) {
-    a->counter -= i;
+    __sync_sub_and_fetch(&a->counter, i);
 }
 
 static inline void env_atomic_inc(env_atomic* a) {
-    a->counter++;
+    env_atomic_add(1, a);
 }
 
 static inline void env_atomic_dec(env_atomic* a) {
-    a->counter--;
+    env_atomic_sub(1, a);
 }
 
 static inline bool env_atomic_dec_and_test(env_atomic* a) {
-    a->counter--;
-    return a->counter == 0;
+    return __sync_sub_and_fetch(&a->counter, 1) == 0;
 }
 
 static inline int env_atomic_add_return(int i, env_atomic* a) {
-    a->counter += i;
-    return a->counter;
+    return __sync_add_and_fetch(&a->counter, i);
 }
 
 static inline int env_atomic_sub_return(int i, env_atomic* a) {
-    a->counter -= i;
-    return a->counter;
+    return __sync_sub_and_fetch(&a->counter, i);
 }
 
 static inline int env_atomic_inc_return(env_atomic* a) {
-    a->counter++;
-    return a->counter;
+    return env_atomic_add_return(1, a);
 }
 
 static inline int env_atomic_dec_return(env_atomic* a) {
-    a->counter--;
-    return a->counter;
+    return env_atomic_sub_return(1, a);
 }
 
 static inline int env_atomic_cmpxchg(env_atomic* a, int old, int new_value) {
-    if (a->counter == old) {
-        a->counter = new_value;
-        return old;
-    } else {
-        return new_value;
-    }
+    return __sync_val_compare_and_swap(&a->counter, old, new_value);
 }
 
 static inline int env_atomic_add_unless(env_atomic* a, int i, int u) {
@@ -376,41 +366,35 @@ static inline int env_atomic_add_unless(env_atomic* a, int i, int u) {
 }
 
 static inline long env_atomic64_read(const env_atomic64* a) {
-    return a->counter;
+    return a->counter; /* TODO */
 }
 
 static inline void env_atomic64_set(env_atomic64* a, long i) {
-    a->counter = i;
+    a->counter = i; /* TODO */
 }
 
 static inline void env_atomic64_add(long i, env_atomic64* a) {
-    a->counter += i;
+    __sync_add_and_fetch(&a->counter, i);
 }
 
 static inline void env_atomic64_sub(long i, env_atomic64* a) {
-    a->counter -= i;
+    __sync_sub_and_fetch(&a->counter, i);
 }
 
 static inline void env_atomic64_inc(env_atomic64* a) {
-    a->counter++;
+    env_atomic64_add(1, a);
 }
 
 static inline void env_atomic64_dec(env_atomic64* a) {
-    a->counter--;
+    env_atomic64_sub(1, a);
 }
 
 static inline long env_atomic64_inc_return(env_atomic64* a) {
-    a->counter--;
-    return a->counter;
+    return __sync_add_and_fetch(&a->counter, 1);
 }
 
 static inline long env_atomic64_cmpxchg(env_atomic64* a, long old_v, long new_v) {
-    if (a->counter == old_v) {
-        a->counter = new_v;
-        return old_v;
-    } else {
-        return new_v;
-    }
+    return __sync_val_compare_and_swap(&a->counter, old_v, new_v);
 }
 
 /* SPIN LOCKS */

--- a/src/overlaybd/cache/ocf_cache/ease_bindings/queue.cpp
+++ b/src/overlaybd/cache/ocf_cache/ease_bindings/queue.cpp
@@ -1,6 +1,8 @@
 #include "queue.h"
 
 #include <photon/thread/thread-pool.h>
+#include <photon/thread/workerpool.h>
+#include <photon/photon.h>
 
 static void *run(void *args) {
     auto queue = (ocf_queue_t)args;
@@ -13,21 +15,31 @@ class QueueKicker {
 public:
     explicit QueueKicker(ocf_queue_t queue) : m_queue(queue) {
     }
+    QueueKicker(ocf_queue_t queue, size_t vcpu_num, int ev_engine, int io_engine, int mode) : m_queue(queue) {
+        work_pool = new photon::WorkPool(vcpu_num, ev_engine, io_engine, mode);
+    }
+    ~QueueKicker() {
+        delete work_pool;
+    }
 
     inline void kick() {
-        m_pool.thread_create(run, m_queue);
+        if (work_pool) {
+            work_pool->async_call(new auto([this](){ run(m_queue); }));
+        } else {
+            photon::thread_create(run, m_queue);
+        }
     }
 
 private:
     /* associated OCF queue */
     ocf_queue_t m_queue;
     /* thread pool */
-    photon::ThreadPool<64> m_pool;
+    photon::WorkPool* work_pool = nullptr;
 };
 
 int init_queues(ocf_queue_t mngt_queue, ocf_queue_t io_queue) {
-    auto mngt_queue_kicker = new QueueKicker(mngt_queue);
-    auto io_queue_kicker = new QueueKicker(io_queue);
+    auto mngt_queue_kicker = new QueueKicker(mngt_queue, 2, 0, 0, 64);
+    auto io_queue_kicker = new QueueKicker(io_queue, 4, photon::INIT_EVENT_EPOLL, photon::INIT_IO_LIBCURL, 64);
 
     ocf_queue_set_priv(mngt_queue, mngt_queue_kicker);
     ocf_queue_set_priv(io_queue, io_queue_kicker);

--- a/src/overlaybd/registryfs/registryfs.cpp
+++ b/src/overlaybd/registryfs/registryfs.cpp
@@ -256,16 +256,21 @@ protected:
     ObjectCache<estring, size_t *> m_meta_size;
     ObjectCache<estring, estring *> m_scope_token;
     ObjectCache<estring, UrlInfo *> m_url_info;
+    photon::mutex mutex;
 
     photon::net::cURL *get_cURL() {
+        mutex.lock();
         auto curl = m_curl_pool.get();
+        mutex.unlock();
         curl->reset_error();
         curl->reset().clear_header().set_cafile(m_caFile.c_str());
         return curl;
     };
 
     void release_cURL(photon::net::cURL *curl) {
+        mutex.lock();
         m_curl_pool.put(curl);
+        mutex.unlock();
     };
 
     int getScopeAuth(const char *url, estring *authurl, estring *scope, uint64_t timeout) {


### PR DESCRIPTION
When "enableThread" option is set to "true" in overlaybd.json, overlaybd device will work in thread mode. 
It benifits when multiple overlaybd devices are running concurrently and CPU has idle cores.
Pay attention that it only works with "ocf" cache ("cacheType" should be "ocf") currently. File cache doesn't have supported multi-thread yet.  
Signed-off-by: yuchen.cc <yuchen.cc@alibaba-inc.com>