### PR TITLE
config: optimize cache config

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,9 +147,10 @@ Default configure file `overlaybd.json` is installed to `/etc/overlaybd/`.
 | logLevel            | DEBUG 0, INFO  1, WARN  2, ERROR 3                                                                    |
 | ioEngine            | IO engine used to open local files: psync 0, libaio 1, posix aio 2.                                   |
 | logPath             | The path for log file, `/var/log/overlaybd.log` is the default value.                                 |
-| registryCacheDir    | The cache directory for remote image data.                                                            |
-| registryCacheSizeGB | The max size of cache, in GB.                                                                         |
-| cacheType           | Cache type used, `file` and `ocf` are supported, `file` is the default.                               |
+| cacheConfig.cacheType   | Cache type used, `file` and `ocf` are supported.                                                  |
+| cacheConfig.cacheDir    | The cache directory for remote image data.                                                        |
+| cacheConfig.cacheSizeGB | The max size of cache, in GB.                                                                     |
+| cacheConfig.refillSize  | The refill size from source, in byte. `262144` is default (256 KB).                               |
 | credentialFilePath(legacy)  | The credential used for fetching images on registry. `/opt/overlaybd/cred.json` is the default value. |
 | credentialConfig.mode | Authentication mode for lazy-loading. <br> - `file` means reading credential from `credentialConfig.path`.  <br> - `http` means sending an http request to `credentialConfig.path` |
 credentialConfig.path | credential file path or url which is determined by `mode`

--- a/src/config.h
+++ b/src/config.h
@@ -73,10 +73,20 @@ struct CredentialConfig : public ConfigUtils::Config {
     APPCFG_PARA(path, std::string, "");
 };
 
+struct CacheConfig : public ConfigUtils::Config {
+    APPCFG_CLASS
+
+    APPCFG_PARA(cacheType, std::string, "");
+    APPCFG_PARA(cacheDir, std::string, "/opt/overlaybd/registry_cache");
+    APPCFG_PARA(cacheSizeGB, uint32_t, 4);
+    APPCFG_PARA(refillSize, uint32_t, 262144);
+    APPCFG_PARA(blockSize, uint32_t, 65536);
+};
+
 struct GlobalConfig : public ConfigUtils::Config {
     APPCFG_CLASS
 
-    APPCFG_PARA(registryCacheDir, std::string, "/opt/overlaybd/registryfs_cache");
+    APPCFG_PARA(registryCacheDir, std::string, "/opt/overlaybd/registry_cache");
     APPCFG_PARA(credentialFilePath, std::string, "/opt/overlaybd/cred.json");
     APPCFG_PARA(credentialConfig, CredentialConfig)
     APPCFG_PARA(registryCacheSizeGB, uint32_t, 4);
@@ -90,6 +100,7 @@ struct GlobalConfig : public ConfigUtils::Config {
     APPCFG_PARA(p2pConfig, P2PConfig);
     APPCFG_PARA(auditPath, std::string, "/var/log/overlaybd-audit.log");
     APPCFG_PARA(registryFsVersion, std::string, "v1");
+    APPCFG_PARA(cacheConfig, CacheConfig);
 };
 
 struct AuthConfig : public ConfigUtils::Config {

--- a/src/example_config/overlaybd-registryv2.json
+++ b/src/example_config/overlaybd-registryv2.json
@@ -1,7 +1,10 @@
 {
     "logLevel": 1,
-    "registryCacheDir": "/opt/overlaybd/registry_cache",
-    "registryCacheSizeGB": 4,
+    "cacheConfig": {
+        "cacheType": "file",
+        "cacheDir": "/opt/overlaybd/registry_cache",
+        "cacheSizeGB": 4
+    },
     "credentialConfig": {
         "mode": "file",
         "path": "/opt/overlaybd/cred.json"

--- a/src/example_config/overlaybd.json
+++ b/src/example_config/overlaybd.json
@@ -1,7 +1,10 @@
 {
     "logLevel": 1,
-    "registryCacheDir": "/opt/overlaybd/registry_cache",
-    "registryCacheSizeGB": 4,
+    "cacheConfig": {
+        "cacheType": "file",
+        "cacheDir": "/opt/overlaybd/registry_cache",
+        "cacheSizeGB": 4
+    },
     "credentialConfig": {
         "mode": "file",
         "path": "/opt/overlaybd/cred.json"

--- a/src/image_service.cpp
+++ b/src/image_service.cpp
@@ -174,9 +174,6 @@ int ImageService::read_global_config_and_set() {
     if (ioengine > 2) {
         LOG_ERROR_RETURN(0, -1, "unknown io_engine: `", ioengine);
     }
-    if (global_conf.cacheType() != "file" && global_conf.cacheType() != "ocf") {
-        LOG_ERROR_RETURN(0, -1, "unknown cache type `", global_conf.cacheType());
-    }
 
     if (global_conf.enableAudit()) {
         std::string auditPath = global_conf.auditPath();
@@ -201,8 +198,6 @@ int ImageService::read_global_config_and_set() {
         }
     }
 
-    LOG_INFO("global config: cache_dir: `, cache_size_GB: `, cache_type: `",
-             global_conf.registryCacheDir(), global_conf.registryCacheSizeGB(), global_conf.cacheType());
     return 0;
 }
 
@@ -264,7 +259,27 @@ int ImageService::init() {
         return -1;
     }
 
-    if (!create_dir(global_conf.registryCacheDir().c_str()))
+    std::string cache_type, cache_dir;
+    uint32_t cache_size_GB, refill_size, block_size;
+    if (global_conf.cacheConfig().cacheType().empty()) {
+        cache_type = global_conf.cacheType();
+        cache_dir = global_conf.registryCacheDir();
+        cache_size_GB = global_conf.registryCacheSizeGB();
+    } else {
+        cache_type = global_conf.cacheConfig().cacheType();
+        cache_dir = global_conf.cacheConfig().cacheDir();
+        cache_size_GB = global_conf.cacheConfig().cacheSizeGB();
+    }
+    refill_size = global_conf.cacheConfig().refillSize();
+    block_size = global_conf.cacheConfig().blockSize();
+
+    if (cache_type != "file" && cache_type != "ocf") {
+        LOG_ERROR_RETURN(0, -1, "unknown cache type `", cache_type);
+    }
+    LOG_INFO("cache config: ", VALUE(cache_type), VALUE(cache_dir),
+                               VALUE(cache_size_GB), VALUE(refill_size));
+
+    if (!create_dir(cache_dir.c_str()))
         return -1;
 
     if (global_fs.remote_fs == nullptr) {
@@ -299,25 +314,23 @@ int ImageService::init() {
             global_fs.remote_fs = registry_fs;
             return 0;
         }
-        if (global_conf.enableThread() == true && global_conf.cacheType() == "file") {
+        if (global_conf.enableThread() == true && cache_type == "file") {
             LOG_ERROR_RETURN(0, -1, "multi-thread has not been valid for file cache");
         }
-        if (global_conf.cacheType() == "file") {
-            auto registry_cache_fs = new_localfs_adaptor(
-                global_conf.registryCacheDir().c_str());
+        if (cache_type == "file") {
+            auto registry_cache_fs = new_localfs_adaptor(cache_dir.c_str());
             if (registry_cache_fs == nullptr) {
                 delete tar_fs;
-                LOG_ERROR_RETURN(0, -1, "new_localfs_adaptor for ` failed",
-                                 global_conf.registryCacheDir().c_str());
+                LOG_ERROR_RETURN(0, -1, "new_localfs_adaptor for ` failed", cache_dir.c_str());
             }
             // file cache will delete its src_fs automatically when destructed
             global_fs.remote_fs = FileSystem::new_full_file_cached_fs(
-                tar_fs, registry_cache_fs, 256 * 1024 /* refill unit 256KB */,
-                global_conf.registryCacheSizeGB() /*GB*/, 10000000,
+                tar_fs, registry_cache_fs, refill_size /* refill unit 256KB */,
+                cache_size_GB /*GB*/, 10000000,
                 (uint64_t)1048576 * 4096, nullptr);
 
-        } else if (global_conf.cacheType() == "ocf") {
-            auto namespace_dir = std::string(global_conf.registryCacheDir() + "/namespace");
+        } else if (cache_type == "ocf") {
+            auto namespace_dir = std::string(cache_dir + "/namespace");
             if (::access(namespace_dir.c_str(), F_OK) != 0 && ::mkdir(namespace_dir.c_str(), 0755) != 0) {
                 LOG_ERRNO_RETURN(0, -1, "failed to create namespace_dir");
             }
@@ -332,12 +345,12 @@ int ImageService::init() {
 
             bool reload_media;
             IFile* media_file;
-            auto media_file_path = std::string(global_conf.registryCacheDir() + "/cache_media");
+            auto media_file_path = std::string(cache_dir + "/cache_media");
             if (::access(media_file_path.c_str(), F_OK) != 0) {
                 reload_media = false;
                 media_file = open_localfile_adaptor(media_file_path.c_str(), O_RDWR | O_CREAT, 0644,
                                                                 ioengine_psync);
-                media_file->fallocate(0, 0, global_conf.registryCacheSizeGB() * 1024UL * 1024 * 1024);
+                media_file->fallocate(0, 0, cache_size_GB * 1024UL * 1024 * 1024);
             } else {
                 reload_media = true;
                 media_file = open_localfile_adaptor(media_file_path.c_str(), O_RDWR, 0644,
@@ -345,7 +358,7 @@ int ImageService::init() {
             }
             global_fs.media_file = media_file;
 
-            global_fs.remote_fs = FileSystem::new_ocf_cached_fs(tar_fs, namespace_fs, 65536, 262144,
+            global_fs.remote_fs = FileSystem::new_ocf_cached_fs(tar_fs, namespace_fs, block_size, refill_size,
                                                                 media_file, reload_media, io_alloc);
         }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -326,7 +326,6 @@ static int dev_open(struct tcmu_device *dev) {
 
             odev->end.wait(1);
             delete odev->loop;
-            delete odev->file;
             LOG_INFO("obd device exit");
         };
 
@@ -356,8 +355,8 @@ static void dev_close(struct tcmu_device *dev) {
         delete odev->work;
     } else {
         delete odev->loop;
-        delete odev->file;
     }
+    delete odev->file;
     delete odev;
     close_cnt++;
     if (close_cnt == 500) {

--- a/src/overlaybd/cache/ocf_cache/ease_bindings/ctx.h
+++ b/src/overlaybd/cache/ocf_cache/ease_bindings/ctx.h
@@ -19,8 +19,8 @@ class ease_ocf_provider;
 /* Src file context */
 struct OcfSrcFileCtx {
     OcfSrcFileCtx(photon::fs::IFile *src_file_, const OcfNamespace::NsInfo &ns_info_,
-                  ease_ocf_provider *provider_)
-        : src_file(src_file_), ns_info(ns_info_), provider(provider_) {
+                  ease_ocf_provider *provider_, const estring &path_)
+        : src_file(src_file_), ns_info(ns_info_), provider(provider_), path(path_) {
     }
 
     ~OcfSrcFileCtx() {
@@ -30,6 +30,7 @@ struct OcfSrcFileCtx {
     photon::fs::IFile *src_file;
     OcfNamespace::NsInfo ns_info;
     ease_ocf_provider *provider;
+    estring path;
 };
 
 /* IO data */

--- a/src/overlaybd/cache/ocf_cache/ease_bindings/volume.cpp
+++ b/src/overlaybd/cache/ocf_cache/ease_bindings/volume.cpp
@@ -4,6 +4,7 @@
 
 #include <photon/common/alog.h>
 #include <photon/common/alog-stdstring.h>
+#include <photon/common/alog-audit.h>
 #include <photon/fs/localfs.h>
 #include <photon/common/io-alloc.h>
 #include <photon/common/iovector.h>
@@ -111,6 +112,7 @@ static void volume_submit_io(struct ocf_io *io) {
                 photon::thread_create11(prefetch_read, vol_io->data->ctx, local_iov.sum(), offset,
                                         vol_io->data->blk_addr);
             }
+            SCOPE_AUDIT("download", AU_FILEOP(src_file->path, offset, ret));
             ret = src_file->src_file->preadv(local_iov.iovec(), local_iov.iovcnt(), offset);
         }
     }

--- a/src/overlaybd/cache/ocf_cache/ocf_cache.cpp
+++ b/src/overlaybd/cache/ocf_cache/ocf_cache.cpp
@@ -256,7 +256,7 @@ IFile *OcfCachedFs::open(const char *pathname, int flags, mode_t mode) {
             LOG_ERROR_RETURN(0, nullptr, "OCF: failed to locate src_file in namespace, path `",
                              path_str);
         }
-        return new OcfSrcFileCtx(src_file, info, m_provider);
+        return new OcfSrcFileCtx(src_file, info, m_provider, path_str);
     };
 
     auto src_file_ctx = m_src_file_pool.acquire(path_str, ctor);


### PR DESCRIPTION
Group cache configs, open refill size config. Compatible with old formats.
Enable ocf cache audit.

See README.md for details

Signed-off-by: yuchen.cc <yuchen.cc@alibaba-inc.com>