### PR TITLE
New Features: LSMTWarpfile & Dolls

### DIFF
--- a/src/overlaybd/lsmt/file.cpp
+++ b/src/overlaybd/lsmt/file.cpp
@@ -14,6 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 #include "file.h"
+#include <cstdint>
+#include <openssl/bio.h>
 #include <string.h>
 #include <stdarg.h>
 #include <memory>
@@ -26,7 +28,12 @@ limitations under the License.
 #include <vector>
 #include <sys/types.h>
 #include <sys/stat.h>
+#include <sys/ioctl.h>
 #include "index.h"
+#include "photon/common/alog.h"
+#include "photon/common/uuid.h"
+#include "photon/fs/filesystem.h"
+#include "photon/fs/virtual-file.h"
 #include <photon/common/alog.h>
 #include <photon/common/utility.h>
 #include <photon/thread/thread.h>
@@ -46,6 +53,13 @@ LogBuffer &operator<<(LogBuffer &log, const SegmentMapping &m) {
     return log.printf((Segment &)m, "--> Mapping[", m.moffset + 0, ',', m.zeroed + 0, ',',
                       m.tag + 0, ']');
 }
+LogBuffer &operator<<(LogBuffer &log, const RemoteMapping &m) {
+    return log.printf("[offset: `, count: `, remote_offset: `]", m.offset + 0, m.count + 0,
+                      m.roffset + 0);
+}
+
+enum class LSMTFileType { RO, RW, SparseRW, WarpFileRO, WarpFile };
+
 struct HeaderTrailer {
     static const uint32_t SPACE = 4096;
     static const uint32_t TAG_SIZE = 256;
@@ -183,6 +197,7 @@ public:
     uint64_t m_data_offset = HeaderTrailer::SPACE / ALIGNMENT;
     uint32_t lsmt_io_cnt = 0;
     uint64_t lsmt_io_size = 0;
+    LSMTFileType m_filetype = LSMTFileType::RO;
 
     virtual ~LSMTReadOnlyFile() {
         LOG_INFO("pread times: `, size: `M", lsmt_io_cnt, lsmt_io_size >> 20);
@@ -192,6 +207,13 @@ public:
             for (auto &x : m_files)
                 safe_delete(x);
         }
+    }
+
+    virtual int vioctl(int request, va_list args) override {
+        if (request == GetType) {
+            return (int)m_filetype;
+        }
+        LOG_ERROR_RETURN(EINVAL, -1, "invaid request code");
     }
 
     virtual int set_max_io_size(size_t _size) override {
@@ -356,15 +378,20 @@ static int write_header_trailer(IFile *file, bool is_header, bool is_sealed, boo
     pht->index_offset = index_offset;
     pht->index_size = index_size;
     pht->virtual_size = args.virtual_size;
+    pht->set_uuid(args.uuid);
+    pht->parent_uuid = args.parent_uuid;
     if (pht->set_tag(args.user_tag, args.len) != 0)
         return -1;
     if (is_header) {
-        LOG_DEBUG("set header UUID");
+        LOG_INFO("write header {virtual_size: `, uuid: `, parent_uuid: `}", args.virtual_size,
+                 pht->uuid.c_str(), pht->parent_uuid.c_str());
     } else {
-        LOG_DEBUG("set trailer UUID");
+        LOG_INFO(
+            "write trailer {index_offset: `, index_size: `, virtual_size: `, uuid: `, parent_uuid: `}",
+            pht->index_offset + 0, pht->index_size + 0, pht->virtual_size + 0, pht->uuid.c_str(),
+            pht->parent_uuid.c_str());
     }
-    pht->set_uuid(args.uuid);
-    pht->parent_uuid = args.parent_uuid;
+
     if (args.parent_uuid.is_null()) {
         LOG_WARN("parent_uuid is null.");
     }
@@ -382,6 +409,13 @@ struct CompactOptions {
     uint64_t io_usleep_time = 0;
     char *TRIM_BLOCK = nullptr;
     size_t trim_blk_size = 0;
+
+    CompactOptions(const vector<IFile *> *files, SegmentMapping *mapping, size_t index_size,
+                   size_t vsize, const CommitArgs *args)
+        : src_files((IFile **)&(*files)[0]), n(files->size()), raw_index(mapping),
+          index_size(index_size), virtual_size(vsize), commit_args(args) {
+        LOG_INFO("generate compact options, file count: `", n);
+    };
 };
 
 static int push_segment(char *buf, char *data, int &data_length, int &prev_end, int zero_detect,
@@ -601,6 +635,7 @@ public:
 
     LSMTFile() {
         m_compacted_idx_size.store(0);
+        m_filetype = LSMTFileType::RW;
     }
 
     ~LSMTFile() {
@@ -616,6 +651,9 @@ public:
     }
 
     virtual int vioctl(int request, va_list args) override {
+        if (request == GetType) {
+            return LSMTReadOnlyFile::vioctl(request, args);
+        }
         if (request != Index_Group_Commit)
             LOG_ERROR_RETURN(EINVAL, -1, "invaid request code");
 
@@ -781,13 +819,8 @@ public:
         auto m_index0 = (IMemoryIndex0 *)m_index;
         unique_ptr<SegmentMapping[]> mapping(m_index0->dump());
 
-        CompactOptions opts;
-        opts.src_files = (IFile **)&m_files[0];
-        opts.n = m_files.size();
-        opts.raw_index = mapping.get();
-        opts.index_size = m_index->size();
-        opts.virtual_size = m_vsize;
-        opts.commit_args = &args;
+        CompactOptions opts(&m_files, mapping.get(), m_index->size(), m_vsize, &args);
+
         atomic_uint64_t _no_use_var(0);
         return compact(opts, _no_use_var);
     }
@@ -873,6 +906,10 @@ class LSMTSparseFile : public LSMTFile {
 public:
     static const off_t BASE_MOFFSET = HeaderTrailer::SPACE;
 
+    LSMTSparseFile() {
+        m_filetype = LSMTFileType::SparseRW;
+    }
+
     virtual int close() override {
         return LSMTReadOnlyFile::close();
     }
@@ -900,8 +937,8 @@ public:
         {
             ret = m_files[m_rw_tag]->pwrite(buf, count, moffset);
             if (ret != (ssize_t)count) {
-                LOG_ERRNO_RETURN(0, -1, "write failed, file:`, ret:`, pos:`, count:`", m_files[m_rw_tag],
-                                 ret, moffset, count);
+                LOG_ERRNO_RETURN(0, -1, "write failed, file:`, ret:`, pos:`, count:`",
+                                 m_files[m_rw_tag], ret, moffset, count);
             }
             LOG_DEBUG("insert segment: `", m);
             static_cast<IMemoryIndex0 *>(m_index)->insert(m);
@@ -914,26 +951,28 @@ public:
         m.moffset = (uint64_t)(m.offset + (HeaderTrailer::SPACE / ALIGNMENT));
         LOG_DEBUG(m);
         static_cast<IMemoryIndex0 *>(m_index)->insert(m);
-        return m_files[m_rw_tag]->trim(m.offset * ALIGNMENT + HeaderTrailer::SPACE, m.length * ALIGNMENT);
+        return m_files[m_rw_tag]->trim(m.offset * ALIGNMENT + HeaderTrailer::SPACE,
+                                       m.length * ALIGNMENT);
     }
 
     // sparse RW File can't support these methods:
     // UNIMPLEMENTED(int commit(const CommitArgs &args) const override);
     UNIMPLEMENTED(int close_seal(IFileRO **reopen_as = nullptr) override);
 
-    static int create_mappings(const IFile *file, vector<SegmentMapping> &mappings) {
+    static int create_mappings(const IFile *file, vector<SegmentMapping> &mappings,
+                               off_t base = BASE_MOFFSET) {
 
-        auto moffset = BASE_MOFFSET;
+        auto moffset = base;
         while (true) {
-            auto begin = const_cast<IFile*>(file)->lseek(moffset, SEEK_DATA);
+            auto begin = const_cast<IFile *>(file)->lseek(moffset, SEEK_DATA);
             if (begin == -1)
                 break;
-            auto end =  const_cast<IFile*>(file)->lseek(begin, SEEK_HOLE);
+            auto end = const_cast<IFile *>(file)->lseek(begin, SEEK_HOLE);
             if (end == -1)
                 break;
             LOG_DEBUG("segment find: [ mbegin: `, mend: ` ]", begin, end);
             uint64_t total_length = (end - begin) / ALIGNMENT;
-            uint64_t prev_offset = ((uint64_t)begin - BASE_MOFFSET) / (uint64_t)ALIGNMENT;
+            uint64_t prev_offset = ((uint64_t)begin - base) / (uint64_t)ALIGNMENT;
             uint64_t prev_moffset = (uint64_t)(begin / ALIGNMENT);
             while (total_length > Segment::MAX_LENGTH) {
                 uint32_t length = Segment::MAX_LENGTH;
@@ -957,6 +996,177 @@ public:
     }
 };
 
+class LSMTWarpFile : public LSMTFile {
+public:
+    const static int READ_BUFFER_SIZE = 65536;
+    LSMTWarpFile() {
+        m_filetype = LSMTFileType::WarpFile;
+    }
+    ssize_t pwrite(const void *buf, size_t count, off_t offset, SegmentType tag) {
+
+        auto moffset = offset;
+        SegmentMapping m{
+            (uint64_t)offset / (uint64_t)ALIGNMENT,
+            (uint32_t)count / (uint32_t)ALIGNMENT,
+            (uint64_t)moffset / (uint64_t)ALIGNMENT,
+        };
+        auto append = [&](const void *buf, SegmentMapping m) -> ssize_t {
+            ssize_t ret = -1;
+            m.tag = (uint8_t)tag;
+            auto file = m_files[(uint8_t)tag];
+            ret = file->pwrite(buf, count, offset);
+            LOG_DEBUG("insert segment: `, filePtr: `", m, file);
+            if (ret != (ssize_t)count) {
+                LOG_ERRNO_RETURN(0, -1, "write failed, file:`, ret:`, pos:`, count:`", file, ret,
+                                 moffset, count);
+            }
+            static_cast<IMemoryIndex0 *>(m_index)->insert(m);
+            append_index(m);
+            return ret;
+        };
+        if (tag == SegmentType::remoteData) {
+            m.moffset = ((RemoteMapping *)buf)->roffset / (uint64_t)ALIGNMENT;
+            auto limit_len = Segment::MAX_LENGTH;
+            size_t nwrite = 0;
+            size_t count = ((RemoteMapping *)buf)->count / (uint64_t)ALIGNMENT;
+            RemoteMapping lba = *(RemoteMapping *)buf;
+            while (count > 0) {
+                m.length = (limit_len < count ? limit_len : count);
+                lba.count = m.length * ALIGNMENT;
+                nwrite += append(&lba, m);
+                count -= m.length;
+                lba.offset += m.length * ALIGNMENT;
+                lba.roffset += m.length * ALIGNMENT;
+                m.forward_offset_to(m.offset + m.length);
+            }
+            return nwrite;
+        }
+        return append(buf, m);
+    }
+
+    virtual ssize_t pwrite(const void *buf, size_t count, off_t offset) override {
+        LOG_DEBUG("write fs meta {offset: `, len: `}", offset, count);
+        auto ret = pwrite(buf, count, offset, SegmentType::fsMeta);
+        if (ret != (ssize_t)count) {
+            LOG_ERRNO_RETURN(0, -1, "pwrite fsmeta failed.");
+        }
+        return count;
+    }
+
+    virtual int vioctl(int request, va_list args) override {
+        if (request == GetType) {
+            return LSMTReadOnlyFile::vioctl(request, args);
+        }
+        if (request != RemoteData)
+            LOG_ERROR_RETURN(EINVAL, -1, "invaid request code");
+
+        va_list tmp;
+        va_copy(tmp, args);
+        auto lba = va_arg(tmp, RemoteMapping);
+        va_end(tmp);
+        LOG_DEBUG("RemoteMapping: {offset: `, count: `, roffset: `}", lba.offset, lba.count,
+                  lba.roffset);
+        auto ret = pwrite(&lba, (ssize_t)sizeof(lba), lba.offset, SegmentType::remoteData);
+        if (ret !=
+            ((lba.count / ALIGNMENT - 1) / Segment::MAX_LENGTH + 1) * sizeof(RemoteMapping)) {
+            LOG_ERRNO_RETURN(0, -1, "pwrite fsmeta failed.");
+        }
+        return 0;
+    }
+
+    class WarpFile : public VirtualReadOnlyFile {
+    public:
+        IFile *m_lba_file = nullptr;
+        IFile *m_target_file = nullptr;
+        WarpFile(IFile *lba_file, IFile *target_file)
+            : m_lba_file(lba_file), m_target_file(target_file) {
+        }
+
+        virtual ssize_t pwrite(const void *buf, size_t count, off_t offset) override {
+            auto lba = *(RemoteMapping *)buf;
+            LOG_DEBUG("write RemoteMapping {offset: `, len: `, roffset: `}", lba.offset, lba.count,
+                      lba.roffset);
+            auto ret = m_lba_file->pwrite(buf, sizeof(lba), offset);
+            if (ret != (ssize_t)count) {
+                LOG_ERRNO_RETURN(0, -1, "pwrite fsmeta failed.");
+            }
+            return count;
+        }
+
+        virtual ssize_t pread(void *buf, size_t count, off_t offset) override {
+            return m_target_file->pread(buf, count, offset);
+        }
+
+        virtual int fstat(struct stat *buf) override {
+            return m_target_file->fstat(buf);
+        }
+
+        UNIMPLEMENTED_POINTER(IFileSystem *filesystem() override);
+    };
+
+    size_t compact(CompactOptions &opts, size_t moffset, size_t &nindex) const {
+
+        auto dest_file = opts.commit_args->as;
+        auto marray = ptr_array(&opts.raw_index[0], opts.index_size);
+        vector<SegmentMapping> compact_index;
+        size_t compacted_idx_size = 0;
+        moffset /= ALIGNMENT;
+        for (auto &m : marray) {
+            if (m.tag == (uint8_t)SegmentType::remoteData) {
+                compact_index.push_back(m);
+                compacted_idx_size++;
+                continue;
+            }
+            compacted_idx_size++;
+            if (m.zeroed) {
+                m.moffset = moffset;
+                compact_index.push_back(m);
+                // there is no need do pcopy if current block is zero-marked.
+                continue;
+            }
+            auto ret = pcopy(opts, m, moffset, compact_index);
+            if (ret < 0)
+                return (int)ret;
+            moffset += ret;
+        }
+        uint64_t index_offset = moffset * ALIGNMENT;
+        auto index_size = compress_raw_index(&compact_index[0], compact_index.size());
+        LOG_DEBUG("write index to dest_file `, offset: `, size: `*`", dest_file, index_offset,
+                  index_size, sizeof(SegmentMapping));
+        auto nwrite = dest_file->write(&compact_index[0], index_size * sizeof(SegmentMapping));
+        if (nwrite != (ssize_t)index_size * sizeof(SegmentMapping)) {
+            LOG_ERRNO_RETURN(0, -1, "write index failed");
+        }
+        nindex = index_size;
+        auto pos = dest_file->lseek(0, SEEK_END);
+        LOG_INFO("write index done, file_size: `", pos);
+        return pos;
+    }
+
+    int commit(const CommitArgs &args) const override {
+
+        auto m_index0 = (IMemoryIndex0 *)m_index;
+        unique_ptr<SegmentMapping[]> mapping(m_index0->dump());
+        CompactOptions opts(&m_files, mapping.get(), m_index->size(), m_vsize, &args);
+        LayerInfo info;
+        info.virtual_size = m_vsize;
+        if (UUID::String::is_valid((args.parent_uuid).c_str())) {
+            LOG_INFO("set parent UUID: `", args.parent_uuid.data);
+            info.parent_uuid.parse(args.parent_uuid);
+        }
+        write_header_trailer(args.as, true, true, true, 0, 0, info);
+        size_t index_size = 0, index_offset = 0;
+        auto ret = compact(opts, HeaderTrailer::SPACE, index_size);
+        if (ret < 0) {
+            LOG_ERRNO_RETURN(0, -1, "compact data failed.");
+        }
+        index_offset = ret - index_size * sizeof(SegmentMapping);
+        LOG_INFO("compact data success, dest_file size: `", ret);
+        write_header_trailer(args.as, false, true, true, index_offset, index_size, info);
+        return 0;
+    }
+};
+
 HeaderTrailer *verify_ht(IFile *file, char *buf) {
     if (file == nullptr) {
         LOG_ERRNO_RETURN(0, nullptr, "invalid file ptr (null).");
@@ -971,7 +1181,9 @@ HeaderTrailer *verify_ht(IFile *file, char *buf) {
     return pht;
 }
 
-static SegmentMapping *do_load_index(IFile *file, HeaderTrailer *pheader_trailer, bool trailer) {
+static SegmentMapping *do_load_index(IFile *file, HeaderTrailer *pheader_trailer, bool trailer,
+                                     bool keep_tag = false) {
+
     ALIGNED_MEM(buf, HeaderTrailer::SPACE, ALIGNMENT4K);
     auto pht = verify_ht(file, buf);
     if (pht == nullptr)
@@ -1022,7 +1234,7 @@ static SegmentMapping *do_load_index(IFile *file, HeaderTrailer *pheader_trailer
     for (size_t i = 0; i < pht->index_size; ++i)
         if (ibuf[i].offset != SegmentMapping::INVALID_OFFSET) {
             ibuf[index_size] = ibuf[i];
-            ibuf[index_size].tag = 0;
+            ibuf[index_size].tag = (keep_tag ? ibuf[i].tag : 0);
             index_size++;
         }
 
@@ -1163,6 +1375,87 @@ IFileRW *create_file_rw(const LayerInfo &args, bool ownership) {
     return rst;
 }
 
+IFileRW *create_warpfile(WarpFileArgs &args, bool ownership) {
+    auto rst = new LSMTWarpFile;
+    rst->m_findex = args.findex;
+    LayerInfo info;
+    info.sparse_rw = false;
+    info.virtual_size = args.virtual_size;
+    info.parent_uuid.parse(args.parent_uuid);
+    info.uuid.parse(args.uuid);
+    write_header_trailer(rst->m_findex, true, false, false, HeaderTrailer::SPACE, 0, info);
+    rst->m_index = create_memory_index0((const SegmentMapping *)nullptr, 0, 0, 0);
+    rst->m_files.resize(2);
+    rst->m_files[(uint8_t)SegmentType::fsMeta] = args.fsmeta;
+    rst->m_files[(uint8_t)SegmentType::remoteData] =
+        new LSMT::LSMTWarpFile::WarpFile(args.lba_file, args.target_file);
+    rst->m_vsize = args.virtual_size;
+    rst->m_file_ownership = ownership;
+    UUID raw;
+    raw.parse(args.uuid);
+    rst->m_uuid.push_back(raw);
+    HeaderTrailer tmp;
+    tmp.version = 2;
+    tmp.sub_version = 0;
+    args.target_file->ftruncate(args.virtual_size);
+    args.fsmeta->ftruncate(args.virtual_size);
+    LOG_INFO("WarpImage Layer: { UUID:`, Parent_UUID: `, Virtual size: `, Version: `.` }", raw,
+             info.parent_uuid, rst->m_vsize, tmp.version, tmp.sub_version);
+    return rst;
+}
+
+IFileRW *open_warpfile_rw(IFile *findex, IFile *fsmeta_file, IFile *lba_file, IFile *target_file,
+                          bool ownership) {
+    // TODO
+    auto rst = new LSMTWarpFile;
+    rst->m_files.resize(2);
+    // auto fsmeta = open_file_rw(fsmeta_file, nullptr, true);
+    LSMT::HeaderTrailer ht;
+    auto p = do_load_index(findex, &ht, false, true);
+    auto pi = create_memory_index0(p, ht.index_size, 0, -1);
+    if (!pi) {
+        delete[] p;
+        LOG_ERROR_RETURN(0, nullptr, "failed to create memory index!");
+    }
+    rst->m_index = pi;
+    rst->m_findex = findex;
+    rst->m_files = {fsmeta_file, new LSMTWarpFile::WarpFile(lba_file, target_file)};
+    rst->m_uuid.resize(1);
+    rst->m_uuid[0].parse(ht.uuid);
+    rst->m_vsize = ht.virtual_size;
+    rst->m_file_ownership = ownership;
+    LOG_INFO("Layer Info: { UUID: `, Parent_UUID: `, Virtual size: `, Version: `.` }", ht.uuid,
+             ht.parent_uuid, rst->m_vsize, ht.version, ht.sub_version);
+    return rst;
+};
+
+IFileRO *open_warpfile_ro(IFile *warpfile, IFile *target_file, bool ownership) {
+    if (!warpfile) {
+        LOG_ERROR("invalid file ptr. file: `", warpfile);
+        return nullptr;
+    }
+    HeaderTrailer ht;
+    auto p = do_load_index(warpfile, &ht, true, true);
+    if (!p)
+        LOG_ERROR_RETURN(EIO, nullptr, "failed to load index from file.");
+    auto pi = create_memory_index(p, ht.index_size, 0, -1);
+    if (!pi) {
+        delete[] p;
+        LOG_ERROR_RETURN(0, nullptr, "failed to create memory index!");
+    }
+    auto rst = new LSMTReadOnlyFile;
+    rst->m_filetype = LSMTFileType::WarpFileRO;
+    rst->m_index = pi;
+    rst->m_files = {warpfile, target_file};
+    rst->m_uuid.resize(1);
+    rst->m_uuid[0].parse(ht.uuid);
+    rst->m_vsize = ht.virtual_size;
+    rst->m_file_ownership = ownership;
+    LOG_INFO("Layer Info: { UUID: `, Parent_UUID: `, Virtual size: `, Version: `.` }", ht.uuid,
+             ht.parent_uuid, rst->m_vsize, ht.version, ht.sub_version);
+    return rst;
+}
+
 struct parallel_load_task {
 
     IFile **files;
@@ -1210,6 +1503,23 @@ struct parallel_load_task {
     }
 };
 
+SegmentMapping *copy_lsmt_index(IFile *file, HeaderTrailer &ht) {
+    auto lsmtfile = (IFileRO *)file;
+    auto n = lsmtfile->index()->size();
+    auto nbytes = n * sizeof(SegmentMapping);
+    ht.index_size = n;
+    struct stat st;
+    lsmtfile->fstat(&st);
+    ht.virtual_size = st.st_size;
+    ht.index_offset = -1;
+    UUID uu;
+    ((IFileRO *)file)->get_uuid(uu);
+    ht.set_uuid(uu);
+    auto p = new SegmentMapping[nbytes];
+    memcpy(p, lsmtfile->index()->buffer(), nbytes);
+    return p;
+}
+
 void *do_parallel_load_index(void *param) {
     parallel_load_task *tm = (parallel_load_task *)param;
     while (true) {
@@ -1218,13 +1528,33 @@ void *do_parallel_load_index(void *param) {
             // error occured from another threads.
             return nullptr;
         }
-        auto p = do_load_index(job->get_file(), &job->ht, true);
-        if (!p) {
-            job->set_error(EIO);
-            LOG_ERROR_RETURN(0, nullptr, "failed to load index from `-th file", job->i);
+        auto file = job->get_file();
+        LOG_INFO("check file if normalfile or LSMTFile");
+        IMemoryIndex *pi = nullptr;
+        LSMT::SegmentMapping *p = nullptr;
+        auto type = file->ioctl(IFileRO::GetType);
+        auto verify_begin = HeaderTrailer::SPACE / ALIGNMENT;
+        if (type != -1) {
+            LOG_INFO("LSMTFileType of file ` is `.", file, type);
+            // copy idx
+            p = copy_lsmt_index(file, job->ht);
+            LOG_INFO("copy index and reset tag, count: `", (int)(job->ht.index_size));
+            for (auto m = p; m < p + job->ht.index_size; m++) {
+                LOG_DEBUG("`", *m);
+                m->tag = 0;
+                m->moffset = m->offset;
+            }
+            verify_begin = 0;
+
+        } else {
+            p = do_load_index(job->get_file(), &job->ht, true);
+            if (!p) {
+                job->set_error(EIO);
+                LOG_ERROR_RETURN(0, nullptr, "failed to load index from `-th file", job->i);
+            }
         }
-        auto pi = create_memory_index(p, job->ht.index_size, HeaderTrailer::SPACE / ALIGNMENT,
-                                      job->ht.index_offset / ALIGNMENT);
+        pi = create_memory_index(p, job->ht.index_size, verify_begin,
+                                 job->ht.index_offset / ALIGNMENT);
         if (!pi) {
             delete[] p;
             job->set_error(EIO);
@@ -1306,13 +1636,7 @@ int merge_files_ro(vector<IFile *> files, const CommitArgs &args) {
     unique_ptr<char[]> DISCARD_BLOCK(new char[ALIGNMENT]);
 
     atomic_uint64_t _no_use_var(0);
-    CompactOptions opts;
-    opts.src_files = (IFile **)&files[0];
-    opts.n = files.size();
-    opts.raw_index = ri.get();
-    opts.index_size = pmi->size();
-    opts.virtual_size = ht.virtual_size;
-    opts.commit_args = &args;
+    CompactOptions opts(&files, ri.get(), pmi->size(), ht.virtual_size, &args);
     int ret = compact(opts, _no_use_var);
     return ret;
 }
@@ -1383,6 +1707,7 @@ IFileRW *stack_files(IFileRW *upper_layer, IFileRO *lower_layers, bool ownership
     if (check_order) {
         if (verify_order(rst->m_files, rst->m_uuid, 1) == false)
             return nullptr;
+        LOG_INFO("check layer's parent uuid success.");
     } else {
         LOG_WARN("STACK FILES WITHOUT CHECK ORDER!!!");
     }

--- a/src/overlaybd/lsmt/index.h
+++ b/src/overlaybd/lsmt/index.h
@@ -26,6 +26,7 @@ IMemoryIndex -> IMemoryIndex0 -> IComboIndex -> Index0 ( set<SegmentMap> ) -> Co
 #include <inttypes.h>
 #include <cstddef>
 #include <assert.h>
+#include <sys/types.h>
 
 namespace LSMT {
 struct Segment {          // 48 + 18 == 64
@@ -82,6 +83,17 @@ struct SegmentMapping : public Segment { // 64 + 55 + 9 == 128
         return SegmentMapping(INVALID_OFFSET, 0, 0);
     }
 } __attribute__((packed));
+
+struct RemoteMapping {
+    off_t offset;
+    uint32_t count;
+    off_t roffset;
+};
+
+enum class SegmentType {
+    fsMeta,
+    remoteData,
+};
 
 // a read-only memory index for log-structured data
 class IMemoryIndex {

--- a/src/tools/overlaybd-commit.cpp
+++ b/src/tools/overlaybd-commit.cpp
@@ -15,6 +15,7 @@
 */
 
 #include <photon/common/alog.h>
+#include <photon/common/alog-stdstring.h>
 #include <photon/fs/localfs.h>
 #include <photon/photon.h>
 #include "../overlaybd/lsmt/file.h"
@@ -50,7 +51,7 @@ int main(int argc, char **argv) {
     string parent_uuid;
     std::string algorithm;
     int block_size = -1;
-    std::string data_file_path, index_file_path, commit_file_path;
+    std::string data_file_path, index_file_path, commit_file_path, remote_mapping_file;
     bool compress_zfile = false;
 
     CLI::App app{"this is overlaybd-commit"};
@@ -62,6 +63,7 @@ int main(int argc, char **argv) {
            "--bs", block_size,
            "The size of a data block in KB. Must be a power of two between 4K~64K [4/8/16/32/64](default 4)");
     app.add_option("data_file", data_file_path, "data file path")->type_name("FILEPATH")->check(CLI::ExistingFile)->required();
+    app.add_option("lba_file", remote_mapping_file, "remoteLBA for warpfile")->type_name("FILEPATH")->check(CLI::ExistingFile);
     app.add_option("index_file", index_file_path, "index file path")->type_name("FILEPATH")->check(CLI::ExistingFile)->required();
     app.add_option("commit_file", commit_file_path, "commit file path")->type_name("FILEPATH")->required();
     CLI11_PARSE(app, argc, argv);
@@ -72,7 +74,15 @@ int main(int argc, char **argv) {
 
     IFile* fdata = open_file(data_file_path.c_str(), O_RDONLY, 0);
     IFile* findex = open_file(index_file_path.c_str(), O_RDONLY, 0);
-    IFileRW* fin = open_file_rw(fdata, findex, true);
+    IFile* flba = nullptr;
+    IFileRW* fin = nullptr;
+    if (not remote_mapping_file.empty()){
+        LOG_INFO("commit LSMTWarpFile with args: {fsmeta: `, remoteMapping: `, index_file: `",
+            data_file_path, remote_mapping_file, index_file_path);
+        fin = open_warpfile_rw(findex, fdata, flba, nullptr, true);
+    } else {
+        fin = open_file_rw(fdata, findex, true);
+    }
     IFile* fout = open_file(commit_file_path.c_str(),  O_RDWR | O_EXCL | O_CREAT,
                     S_IRUSR | S_IWUSR | S_IRGRP | S_IROTH);
     auto out = fout;


### PR DESCRIPTION
This PR contains two key features:

- __LSMTWarpfile__
   A new LSMT format that contains the target file index but does not contain any content

- __Dolls:__
    
      Support multiple sub-LSMTReadOnlyFiles like a 'Dolls'
    
      LSMTReadOnlyFile
            |
            m_files[0]--IFile
            |
            m_files[1]--LSMTReadOnlyFile
            |                     |
            m_files[2]--IFile     m_files[0]--LSMTReadOnlyFile
            |                     |
            m_files[3]            m_files[1]--IFile
            |                     |
            ...                   ...