### PR TITLE
Add failover for p2p download

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -58,3 +58,6 @@ install(FILES example_config/overlaybd.json DESTINATION /etc/overlaybd/)
 install(FILES example_config/cred.json DESTINATION /opt/overlaybd/)
 
 add_subdirectory(tools)
+if (BUILD_TESTING)
+    add_subdirectory(test)
+endif ()

--- a/src/image_service.cpp
+++ b/src/image_service.cpp
@@ -16,15 +16,15 @@
 #include "image_service.h"
 #include "config.h"
 #include "image_file.h"
-#include <photon/common/alog-stdstring.h>
 #include <photon/common/alog.h>
+#include <photon/common/alog-stdstring.h>
 #include <photon/common/io-alloc.h>
 #include <photon/fs/localfs.h>
-#include <photon/net/curl.h>
-#include <photon/thread/thread.h>
-#include <photon/common/alog.h>
-#include <photon/net/curl.h>
 #include <photon/fs/path.h>
+#include <photon/net/curl.h>
+#include <photon/net/http/url.h>
+#include <photon/net/socket.h>
+#include <photon/thread/thread.h>
 #include "overlaybd/cache/cache.h"
 #include "overlaybd/registryfs/registryfs.h"
 #include "overlaybd/tar_file.h"
@@ -259,6 +259,24 @@ static std::string cache_fn_trans_sha256(std::string_view path) {
     return std::string(photon::fs::Path(path).basename());
 }
 
+bool check_accelerate_url(std::string_view a_url) {
+    photon::net::http::URL url(a_url);
+    std::string host = url.host().data();
+    auto pos = host.find(":");
+    if (pos != host.npos) {
+        host.resize(pos);
+    }
+    auto cli = photon::net::new_tcp_socket_client();
+    DEFER({ delete cli; });
+    LOG_DEBUG("Connecting");
+    auto sock = cli->connect({photon::net::IPAddr(host.c_str()), url.port()});
+    DEFER({ delete sock; });
+    if (sock == nullptr) {
+        LOG_WARN("P2P accelerate url invalid");
+    }
+    return sock != nullptr;
+}
+
 int ImageService::init() {
     if (read_global_config_and_set() < 0) {
         return -1;
@@ -310,7 +328,6 @@ int ImageService::init() {
         global_fs.srcfs = registry_fs;
 
         if (global_conf.p2pConfig().enable() == true) {
-            ((RegistryFS*)registry_fs)->setAccelerateAddress(global_conf.p2pConfig().address().c_str());
             global_fs.remote_fs = registry_fs;
             return 0;
         }
@@ -386,6 +403,12 @@ ImageFile *ImageService::create_image_file(const char *config_path) {
         defaultDlCfg.HasMember("download")) {
         cfg.AddMember("download", defaultDlCfg["download"], cfg.GetAllocator());
     }
+    std::string accelerate_url = "";
+    if (global_conf.p2pConfig().enable() &&
+        check_accelerate_url(global_conf.p2pConfig().address())) {
+        accelerate_url = global_conf.p2pConfig().address();
+    }
+    ((RegistryFS*)(global_fs.remote_fs))->setAccelerateAddress(accelerate_url.c_str());
 
     auto resFile = cfg.resultFile();
     ImageFile *ret = new ImageFile(cfg, *this);

--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -1,21 +1,17 @@
-cmake_minimum_required(VERSION 3.11)
+include_directories($ENV{GFLAGS}/include)
+link_directories($ENV{GFLAGS}/lib)
 
-find_package(rapidjson REQUIRED)
+include_directories($ENV{GTEST}/googletest/include)
+link_directories($ENV{GTEST}/lib)
 
-set(CURL_STATICLIB on)
-add_definitions(-DCURL_STATICLIB)
-
-INCLUDE_DIRECTORIES(
+add_executable(curl_test test.cpp)
+target_include_directories(curl_test PUBLIC
     ${PHOTON_INCLUDE_DIR}
     ${rapidjson_SOURCE_DIR}/include
 )
+target_link_libraries(curl_test gtest gtest_main gflags pthread photon_static overlaybd_lib overlaybd_image_lib)
 
-add_executable(simple_auth_srv simple_auth_server.cpp)
-
-target_link_libraries(simple_auth_srv
-photon_static
-rt
-resolv
-aio
-pthread
+add_test(
+    NAME curl_test
+    COMMAND ${EXECUTABLE_OUTPUT_PATH}/curl_test
 )

--- a/src/test/test.cpp
+++ b/src/test/test.cpp
@@ -1,0 +1,70 @@
+/*
+   Copyright The Overlaybd Authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+#include <gtest/gtest.h>
+#include "photon/common/alog.h"
+#include "photon/thread/thread.h"
+#include "photon/net/http/server.h"
+#include "photon/net/socket.h"
+#include "photon/photon.h"
+#include "photon/net/http/url.h"
+#include "photon/net/socket.h"
+#include "photon/io/fd-events.h"
+#include "photon/net/curl.h"
+
+#include <fcntl.h>
+
+#include "../image_service.cpp"
+
+TEST(ImageTest, AccelerateURL) {
+    auto tcpserver = photon::net::new_tcp_socket_server();
+    tcpserver->timeout(1000UL*1000);
+    tcpserver->setsockopt(SOL_SOCKET, SO_REUSEPORT, 1);
+    tcpserver->bind(64208, photon::net::IPAddr("127.0.0.1"));
+    tcpserver->listen();
+    DEFER(delete tcpserver);
+    auto server = photon::net::http::new_http_server();
+    DEFER(delete server);
+    auto test_handle = [&](void*, photon::net::http::Request &req, photon::net::http::Response &resp, std::string_view) -> int {
+        LOG_INFO("test handle...");
+        return 0;
+    };
+    server->add_handler({nullptr, &test_handle});
+    tcpserver->set_handler(server->get_connection_handler());
+    tcpserver->start_loop();
+
+
+    EXPECT_EQ(check_accelerate_url("https://127.0.0.1:64208"), true);
+    EXPECT_EQ(check_accelerate_url("https://localhost:64208/accelerate"), true);
+    EXPECT_EQ(check_accelerate_url("https://127.0.0.1:64208/accelerate"), true);
+
+    EXPECT_EQ(check_accelerate_url("aaa"), false);
+    EXPECT_EQ(check_accelerate_url("https://localhost:64209/accelerate"), false);
+    EXPECT_EQ(check_accelerate_url("https://127.0.0.1:64209/accelerate"), false);
+
+}
+
+int main(int argc, char** argv) {
+    photon::vcpu_init();
+    photon::fd_events_init();
+    photon::net::cURL::init();
+    ::testing::InitGoogleTest(&argc, argv);
+    auto ret = RUN_ALL_TESTS();
+    photon::net::cURL::fini();
+    photon::fd_events_fini();
+    photon::vcpu_fini();
+    return ret;
+}


### PR DESCRIPTION
- Change to on-demand download while p2p accelerate_url invalid
- Add a unit test for p2p failover.

Signed-off-by: Haoqi Miao <miaohaoqi.mhq@alibaba-inc.com>