### PR TITLE
fix bug of overlaybd-create, untar_meta_only

### DIFF
--- a/src/overlaybd/untar/libtar.cpp
+++ b/src/overlaybd/untar/libtar.cpp
@@ -387,7 +387,7 @@ int Tar::extract_regfile_meta_only(const char *filename) {
 
     auto p = file->lseek(0, SEEK_CUR);
     fout->fallocate(0, 0, size);
-    struct photon::fs::fiemap_t<512> fie(0, size);
+    struct photon::fs::fiemap_t<8192> fie(0, size);
     fout->fiemap(&fie);
     for (int i = 0; i < fie.fm_mapped_extents; i++) {
         LSMT::RemoteMapping lba;

--- a/src/tools/overlaybd-create.cpp
+++ b/src/tools/overlaybd-create.cpp
@@ -49,7 +49,7 @@ int main(int argc, char **argv) {
     string parent_uuid;
     bool sparse = false;
     std::string data_file_path, index_file_path, warp_index_path;
-    bool build_fastoci;
+    bool build_fastoci = false;
 
     CLI::App app{"this is overlaybd-create"};
     app.add_option("-u", parent_uuid, "parent uuid");


### PR DESCRIPTION
- overlaybd-create: variable of flag `--fastoci` is not given initial values
- extract_regfile_meta_only: we found the size of extents of some files could be larger than 512 when working with fastoci convertion.