### PR TITLE
disable gzip cache when targetDigest is not set

### DIFF
--- a/src/image_file.cpp
+++ b/src/image_file.cpp
@@ -287,7 +287,7 @@ int ImageFile::open_lower_layer(IFile *&file, ImageConfigNS::LayerConfig &layer,
             LOG_ERROR_RETURN(0, -1, "open(`),`:`", layer.gzipIndex(), errno, strerror(errno));
         }
         target_file = new_gzfile(target_file, gz_index, true);
-        if (image_service.global_conf.gzipCacheConfig().enable()) {
+        if (image_service.global_conf.gzipCacheConfig().enable() && layer.targetDigest() != "") {
             target_file = image_service.global_fs.gzcache_fs->
                           open_cached_gzip_file(target_file, layer.targetDigest().c_str());
         }


### PR DESCRIPTION
TargetDigest is required to use gzip cache, but not for fastoci.