### PR TITLE
Add e2e test for FastOCI & Update workflow environment to Ubuntu-22.04

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -47,7 +47,7 @@ jobs:
       shell: bash
       run: make -j64
 
-    - name: E2E Test
+    - name: E2E Test OverlayBD
       working-directory: ${{github.workspace}}/build
       shell: bash
       run: |
@@ -67,10 +67,39 @@ jobs:
         sudo apt-get install -y lsscsi
         dev=`lsscsi | grep TCMU | awk '{print $7}'`
         echo $dev
-        sudo mkdir mp
-        sudo mount -o ro $dev mp
-        ls mp
-
+        sudo mkdir obd_mp
+        sudo mount -o ro $dev obd_mp
+        ls obd_mp
+        sudo umount obd_mp
+        ls -l /sys/kernel/config/target/loopback/naa.123456789abcdef/tpgt_1/lun/lun_0/vol1
+        sudo unlink /sys/kernel/config/target/loopback/naa.123456789abcdef/tpgt_1/lun/lun_0/vol1
+    - name: E2E Test FastOCI
+      working-directory: ${{github.workspace}}/build
+      shell: bash
+      run: |
+        sudo make install
+        sudo cp ${{github.workspace}}/src/example_config/overlaybd-registryv2.json /etc/overlaybd/overlaybd.json
+        sudo systemctl enable /opt/overlaybd/overlaybd-tcmu.service
+        sudo systemctl start overlaybd-tcmu
+        sudo systemctl status overlaybd-tcmu
+        sudo wget https://overlaybd.blob.core.windows.net/overlaybd/e2etest.tar.gz
+        sudo mkdir -p /var/lib/overlaybd/test/
+        sudo tar -zxvf e2etest.tar.gz -C /var/lib/overlaybd/test/
+        sudo mkdir -p /sys/kernel/config/target/core/user_1/vol2
+        echo -n dev_config=overlaybd//var/lib/overlaybd/test/20/block/config.v1.json | sudo tee /sys/kernel/config/target/core/user_1/vol2/control
+        echo -n 1 | sudo tee /sys/kernel/config/target/core/user_1/vol2/enable
+        sudo mkdir -p /sys/kernel/config/target/loopback/naa.987654321abcdef/tpgt_1/lun/lun_0
+        echo -n "naa.987654321abcdef" | sudo tee /sys/kernel/config/target/loopback/naa.987654321abcdef/tpgt_1/nexus
+        sudo ln -s /sys/kernel/config/target/core/user_1/vol2 /sys/kernel/config/target/loopback/naa.987654321abcdef/tpgt_1/lun/lun_0/vol2
+        lsblk
+        sudo apt-get install -y lsscsi
+        dev=`lsscsi | grep TCMU | awk '{print $7}'`
+        echo $dev
+        sudo mkdir foci_mp
+        sudo mount -o ro $dev foci_mp
+        ls foci_mp
+        sudo umount foci_mp
+        sudo unlink /sys/kernel/config/target/loopback/naa.987654321abcdef/tpgt_1/lun/lun_0/vol2
     - name: Unit Test
       working-directory: ${{github.workspace}}/build
       shell: bash

--- a/.github/workflows/dev-release.yml
+++ b/.github/workflows/dev-release.yml
@@ -11,7 +11,7 @@ env:
 jobs:
   dev-build-rpm:
     name: "Development Release Rpm"
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
     container: centos:7
 
     steps:
@@ -43,7 +43,8 @@ jobs:
 
   dev-build-deb:
     name: "Development Release Deb"
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
+    container: ubuntu:18.04
 
     steps:
     - uses: actions/checkout@v3
@@ -51,24 +52,25 @@ jobs:
     - name: Install Dependencies
       shell: bash
       run: |
-        sudo apt-get update -y
-        sudo apt-get install -y libgflags-dev libcurl4-openssl-dev libssl-dev libaio-dev libnl-3-dev libnl-genl-3-dev rpm
-        sudo apt-get install -y uuid-dev libjson-c-dev libkmod-dev libsystemd-dev autoconf automake libtool libpci-dev nasm libzstd-dev libext2fs-dev
-
-    - name: Create Build Environment
-      run: cmake -E make_directory ${{ github.workspace }}/build
-
-    - name: Configure CMake
-      shell: bash
-      working-directory: ${{ github.workspace }}/build
-      run: |
-        git submodule update --init
-        cmake ${{ github.workspace }} -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DBUILD_TESTING=0 -DENABLE_DSA=0 -DENABLE_ISAL=0
+        apt-get update -y
+        apt-get install -y libgflags-dev libcurl4-openssl-dev libssl-dev libaio-dev libnl-3-dev libnl-genl-3-dev rpm git wget make g++
+        apt-get install -y uuid-dev libjson-c-dev libkmod-dev libsystemd-dev autoconf automake libtool libpci-dev nasm libzstd-dev libext2fs-dev zlib1g-dev
+        wget https://cmake.org/files/v3.15/cmake-3.15.0-Linux-x86_64.tar.gz
+        tar -zxvf cmake-3.15.0-Linux-x86_64.tar.gz
+        cp -r cmake-3.15.0-Linux-x86_64 /usr/local/
 
     - name: Build
-      working-directory: ${{ github.workspace }}/build
       shell: bash
       run: |
+        export PATH="/usr/local/cmake-3.15.0-Linux-x86_64/bin:$PATH"
+        echo git fetching ${{ github.repository }}@${{ github.sha }}
+        git clone https://github.com/${{ github.repository }} overlaybd
+        cd overlaybd
+        git checkout ${{ github.sha }}
+        git submodule update --init
+        mkdir build
+        cd build
+        cmake .. -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DBUILD_TESTING=0 -DENABLE_DSA=0 -DENABLE_ISAL=0 -DCMAKE_C_COMPILER=/usr/bin/gcc -DCMAKE_CXX_COMPILER=/usr/bin/g++
         make -j64
         cpack
 
@@ -76,7 +78,7 @@ jobs:
       uses: actions/upload-artifact@v3
       with:
         name: release-deb
-        path: ${{ github.workspace }}/build/overlaybd-*.deb
+        path: overlaybd/build/overlaybd-*.deb
 
   dev-release:
     runs-on: ubuntu-20.04


### PR DESCRIPTION
Add e2e test for FastOCI:
- download a FastOCI meta image
- create a TCMU block device
- mount to a directory and show image content

Update workflow environment to Ubuntu-22.04:
- the Ubuntu-18.04 environment is deprecated and will be removed on April 1st, 2023, [here for more details](https://github.com/actions/runner-images/issues/6002)