### PR TITLE
trace: support replay with trace file

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -358,6 +358,7 @@ static void dev_close(struct tcmu_device *dev) {
     }
     delete odev->file;
     delete odev;
+    LOG_INFO("dev closed `", tcmu_get_path(dev));
     close_cnt++;
     if (close_cnt == 500) {
         malloc_trim(128 * 1024);

--- a/src/prefetch.cpp
+++ b/src/prefetch.cpp
@@ -232,6 +232,7 @@ private:
             LOG_ERRNO_RETURN(0, -1, "Prefetch: open OK file failed");
         }
         close(ok_fd);
+        LOG_INFO("Prefetch: Record ` records", m_record_array.size());
         return 0;
     }
 


### PR DESCRIPTION
- support replay when trace file is set, and not empty.
- move prefetch file outside to enable trace record when using local blobs.