### PR TITLE
make p2pConfig compatible with data-accelerator/dadi-p2proxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ Default configure file `overlaybd.json` is installed to `/etc/overlaybd/`.
     },
     "p2pConfig": {
         "enable": false,
-        "address": "localhost:9731/accelerator"
+        "address": "localhost:19145/dadip2p"
     },
     "exporterConfig": {
         "enable": false,
@@ -181,7 +181,7 @@ Default configure file `overlaybd.json` is installed to `/etc/overlaybd/`.
 | download.delayExtra | A random extra delay is attached to delay, avoiding too many tasks started at the same time.          |
 | download.maxMBps    | The speed limit in MB/s for a downloading task.                                                       |
 | p2pConfig.enable    | Whether p2p proxy is enabled or not.                                                                  |
-| p2pConfig.address   | The proxy for p2p download.                                                                           |
+| p2pConfig.address   | The proxy for p2p download, the format is `localhost:<P2PConfig.Port>/<P2PConfig.APIKey>`, depending on dadip2p.yaml |
 | exporterConfig.enable         | whether or not create a server to show Prometheus metrics.                                  |
 | exporterConfig.uriPrefix      | URI prefix for export metrics.                                                              |
 | exporterConfig.port           | port for http server to show metrics.                                                       |

--- a/src/example_config/overlaybd-registryv2.json
+++ b/src/example_config/overlaybd-registryv2.json
@@ -21,7 +21,7 @@
     },
     "p2pConfig": {
         "enable": false,
-        "address": "localhost:9731/accelerator"
+        "address": "localhost:19145/dadip2p"
     },
     "enableAudit": true,
     "auditPath": "/var/log/overlaybd-audit.log",

--- a/src/example_config/overlaybd.json
+++ b/src/example_config/overlaybd.json
@@ -26,7 +26,7 @@
     },
     "p2pConfig": {
         "enable": false,
-        "address": "localhost:9731/accelerator"
+        "address": "localhost:19145/dadip2p"
     },
     "exporterConfig": {
         "enable": false,


### PR DESCRIPTION
In `overlaybd.json`, the format of `p2pConfig.address` is `localhost:<P2PConfig.Port>/<P2PConfig.APIKey>`, depending on `dadip2p.yaml`.

If using default `dadip2p.yaml` in [dadi-p2proxy](https://github.com/data-accelerator/dadi-p2proxy), `overlaybd.json` should be
```json
{
    ...
    "p2pConfig": {
        "enable": true,
        "address": "localhost:19145/dadip2p"
    }
    ...
}
```