### PR TITLE
support lsmt seal and commit sealed

### DIFF
--- a/src/bk_download.cpp
+++ b/src/bk_download.cpp
@@ -29,6 +29,7 @@
 #include <sys/stat.h>
 #include <unistd.h>
 #include "switch_file.h"
+#include "image_file.h"
 
 using namespace photon::fs;
 

--- a/src/bk_download.h
+++ b/src/bk_download.h
@@ -24,7 +24,6 @@ class ISwitchFile;
 namespace BKDL {
 
 static std::string DOWNLOAD_TMP_NAME = ".download";
-static std::string COMMIT_FILE_NAME = "overlaybd.commit";
 
 bool check_downloaded(const std::string &dir);
 

--- a/src/image_file.cpp
+++ b/src/image_file.cpp
@@ -258,11 +258,18 @@ int ImageFile::open_lower_layer(IFile *&file, ImageConfigNS::LayerConfig &layer,
     } else {
         // open downloaded blob or remote blob
         if (BKDL::check_downloaded(layer.dir())) {
-            opened = layer.dir() + "/" + BKDL::COMMIT_FILE_NAME;
+            opened = layer.dir() + "/" + COMMIT_FILE_NAME;
             file = __open_ro_file(opened);
         } else {
-            opened = layer.digest();
-            file = __open_ro_remote(layer.dir(), layer.digest(), layer.size(), index);
+            auto sealed = layer.dir() + "/" + SEALED_FILE_NAME;
+            if (::access(sealed.c_str(), 0) == 0) {
+                // open sealed blob
+                opened = sealed;
+                file = __open_ro_file(opened);
+            } else {
+                opened = layer.digest();
+                file = __open_ro_remote(layer.dir(), layer.digest(), layer.size(), index);
+            }
         }
     }
 

--- a/src/image_file.h
+++ b/src/image_file.h
@@ -36,6 +36,9 @@
 #include <photon/thread/thread11.h>
 #include "overlaybd/lsmt/file.h"
 
+static std::string COMMIT_FILE_NAME = "overlaybd.commit";
+static std::string SEALED_FILE_NAME = "overlaybd.sealed";
+
 class ImageFile : public photon::fs::ForwardFile {
 public:
     ImageFile(ImageConfigNS::ImageConfig &_conf, ImageService &is)


### PR DESCRIPTION
After `close_seal()` in overlaybd-commit, we can open this layer as a RO file. This has an accelerating effect on image construction, we can seal it in build, and compress it to Zfile in image push.