### PR TITLE
chore: add issue and pr templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yaml
@@ -1,0 +1,63 @@
+#  Copyright The Overlaybd Authors
+
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+
+#      http://www.apache.org/licenses/LICENSE-2.0
+
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+name: Bug Report
+description: File a bug report
+labels: [bug]
+body:
+  - type: markdown
+    id: preface
+    attributes:
+      value: |
+        Thank you for reporting bugs to Overlaybd!
+  - type: textarea
+    id: environment
+    validations:
+      required: true
+    attributes:
+      label: What happened in your environment?
+      description: "Please also attach logs here."
+  - type: textarea
+    id: expect
+    attributes:
+      label: "What did you expect to happen?"
+  - type: textarea
+    id: reproduce
+    validations:
+      required: true
+    attributes:
+      label: "How can we reproduce it?"
+      description: "Please tell us your environment information as minimally and precisely as possible."
+  - type: textarea
+    id: version
+    validations:
+      required: true
+    attributes:
+      label: What is the version of your Overlaybd?
+      description: "You can find the released versoins from https://github.com/containerd/overlaybd/releases."
+  - type: input
+    id: os
+    validations:
+      required: true
+    attributes:
+      label: What is your OS environment?
+      description: "e.g. Ubuntu 22.04"
+  - type: checkboxes
+    id: idea
+    attributes:
+      label: "Are you willing to submit PRs to fix it?"
+      description: "This is absolutely not required, but we are happy to guide you in the contribution process
+        especially when you already have a good proposal or understanding of how to implement it. Join us at https://slack.cncf.io/ and choose #overlaybd channel."
+      options:
+        - label: Yes, I am willing to fix it.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,19 @@
+#  Copyright The Overlaybd Authors
+
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+
+#      http://www.apache.org/licenses/LICENSE-2.0
+
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+blank_issues_enabled: true
+contact_links:
+  - name: Ask a question or request support in the community
+    url: https://github.com/containerd/overlaybd/discussions/
+    about: Ask a question or request support for using Overlaybd

--- a/.github/ISSUE_TEMPLATE/feature-request.yaml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yaml
@@ -1,0 +1,48 @@
+#  Copyright The Overlaybd Authors
+
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+
+#      http://www.apache.org/licenses/LICENSE-2.0
+
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+name: Feature Request
+description: File a feature request
+labels: [enhancement]
+body:
+  - type: markdown
+    id: preface
+    attributes:
+      value: "Thank you for submitting new features for Overlaybd."
+  - type: input
+    id: version
+    attributes:
+      label: "What is the version of your Overlaybd"
+      description: "You can find the released versoins from https://github.com/containerd/overlaybd/releases."
+  - type: textarea
+    id: description
+    attributes:
+      label: "What would you like to be added?"
+    validations:
+      required: true
+  - type: textarea
+    id: solution
+    attributes:
+      label: "Why is this needed for Overlaybd?"
+      description: "Please describe your user story or scenario."
+    validations:
+      required: true
+  - type: checkboxes
+    id: idea
+    attributes:
+      label: "Are you willing to submit PRs to contribute to this feature?"
+      description: "This is absolutely not required, but we are happy to guide you in the contribution process
+        especially when you already have a good proposal or understanding of how to implement it. Join us at https://slack.cncf.io/ and choose #overlaybd channel."
+      options:
+        - label: Yes, I am willing to implement it.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,12 @@
+**What this PR does / why we need it**:
+
+**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
+Fixes #
+
+**Please check the following list**:
+- [ ]  Does the affected code have corresponding tests, e.g. unit test, E2E test?
+- [ ]  Does this change require a documentation update?
+- [ ]  Does this introduce breaking changes that would require an announcement or bumping the major version?
+- [ ]  Do all new files have an appropriate license header?
+
+<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues directly to https://github.com/containerd/overlaybd/blob/main/MAINTAINERS. -->


### PR DESCRIPTION
The change provides the guidance for contributors to open issue and pr.