### PR TITLE
fix certificate error when wget cmake

### DIFF
--- a/.github/workflows/release/build.sh
+++ b/.github/workflows/release/build.sh
@@ -61,11 +61,11 @@ elif [[ ${OS} =~ "mariner" ]]; then
 fi
 
 if [[ ${ARCH} == "x86_64" ]]; then
-    wget https://cmake.org/files/v3.15/cmake-3.15.0-Linux-x86_64.tar.gz
+    wget --no-check-certificate https://cmake.org/files/v3.15/cmake-3.15.0-Linux-x86_64.tar.gz
     tar -zxf cmake-3.15.0-Linux-x86_64.tar.gz -C /usr/local/
     export PATH="/usr/local/cmake-3.15.0-Linux-x86_64/bin:$PATH"
 else
-    wget https://cmake.org/files/v3.20/cmake-3.20.6-linux-aarch64.tar.gz
+    wget --no-check-certificate https://cmake.org/files/v3.20/cmake-3.20.6-linux-aarch64.tar.gz
     tar -zxf cmake-3.20.6-linux-aarch64.tar.gz -C /usr/local/
     export PATH="/usr/local/cmake-3.20.6-linux-aarch64/bin:$PATH"
 fi


### PR DESCRIPTION
**What this PR does / why we need it**:
Release building: fix certificate error when wget cmake in centos 8
`ERROR: The certificate of 'cmake.org' is not trusted.`
Add flag `--no-check-certificate` for `wget`

**Please check the following list**:
- [ ]  Does the affected code have corresponding tests, e.g. unit test, E2E test?
- [ ]  Does this change require a documentation update?
- [ ]  Does this introduce breaking changes that would require an announcement or bumping the major version?
- [ ]  Do all new files have an appropriate license header?

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues directly to https://github.com/containerd/overlaybd/blob/main/MAINTAINERS. -->
