### PR TITLE
fix race condition in bk_download verify;

### DIFF
--- a/src/bk_download.h
+++ b/src/bk_download.h
@@ -32,7 +32,7 @@ public:
     std::string dir;
     uint32_t try_cnt;
 
-    bool download(int &running);
+    bool download();
     bool lock_file();
     void unlock_file();
 
@@ -43,14 +43,14 @@ public:
     }
     BkDownload(ISwitchFile *sw_file, photon::fs::IFile *src_file, size_t file_size,
                const std::string dir, int32_t limit_MB_ps, int32_t try_cnt, ImageFile *image_file,
-               std::string digest)
+               std::string digest, int &running)
         : sw_file(sw_file), src_file(src_file), file_size(file_size), dir(dir),
-          limit_MB_ps(limit_MB_ps), try_cnt(try_cnt), image_file(image_file), digest(digest) {
+          limit_MB_ps(limit_MB_ps), try_cnt(try_cnt), image_file(image_file), digest(digest), running(running) {
     }
 
 private:
     void switch_to_local_file();
-    bool download_blob(int &running);
+    bool download_blob();
     bool download_done();
 
     ISwitchFile *sw_file = nullptr;
@@ -60,6 +60,7 @@ private:
     std::string digest;
     size_t file_size;
     bool force_download = false;
+    int &running;
 };
 
 void bk_download_proc(std::list<BKDL::BkDownload *> &, uint64_t, int &);

--- a/src/image_file.cpp
+++ b/src/image_file.cpp
@@ -185,7 +185,7 @@ IFile *ImageFile::__open_ro_remote(const std::string &dir, const std::string &di
         } else {
             BKDL::BkDownload *obj =
                 new BKDL::BkDownload(switch_file, srcfile, size, dir, conf.download().maxMBps(),
-                                     conf.download().tryCnt(), this, digest);
+                                     conf.download().tryCnt(), this, digest, m_status);
             LOG_DEBUG("add to download list for `", dir);
             dl_list.push_back(obj);
         }


### PR DESCRIPTION
**What this PR does / why we need it**:
fix race condition in bk_download verify, which may cause overlaybd-tcmu hang.

**Please check the following list**:
- [ ]  Does the affected code have corresponding tests, e.g. unit test, E2E test?
- [ ]  Does this change require a documentation update?
- [ ]  Does this introduce breaking changes that would require an announcement or bumping the major version?
- [ ]  Do all new files have an appropriate license header?

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues directly to https://github.com/containerd/overlaybd/blob/main/MAINTAINERS. -->
