### PR TITLE
bk_download: wait verify finish

### DIFF
--- a/src/bk_download.cpp
+++ b/src/bk_download.cpp
@@ -116,10 +116,9 @@ bool BkDownload::download_done() {
         done.signal(1);
     });
     sha256_thread.detach();
-    while (running == 1) {
-        if (done.wait(1, 200 * 1000) == 0)
-            break;
-    }
+    // wait verify finish
+    done.wait(1);
+
     if (shares != digest) {
         LOG_ERROR("verify checksum ` failed (expect: `, got: `)", old_name, digest, shares);
         force_download = true; // force redownload next time


### PR DESCRIPTION
**What this PR does / why we need it**:
fix bug in background download when bk_downloa thread is interrupt while verify thread still running.

**Please check the following list**:
- [ ]  Does the affected code have corresponding tests, e.g. unit test, E2E test?
- [ ]  Does this change require a documentation update?
- [ ]  Does this introduce breaking changes that would require an announcement or bumping the major version?
- [ ]  Do all new files have an appropriate license header?

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues directly to https://github.com/containerd/overlaybd/blob/main/MAINTAINERS. -->
