### PR TITLE
[Feat] LSMTSparseFile support close_seal()

### DIFF
--- a/src/overlaybd/lsmt/test/test.cpp
+++ b/src/overlaybd/lsmt/test/test.cpp
@@ -604,6 +604,23 @@ TEST_F(FileTest3, stack_files) {
     delete file;
 }
 
+TEST_F(FileTest3, sparsefile_close_seal) {
+    CleanUp();
+    cout << "generating " << FLAGS_layers << " RO layers by randwrite()" << endl;
+    auto file = create_a_layer(true);
+    IFileRO *fdup;
+    file->close_seal(&fdup);
+    verify_file(fdup);
+    auto fcommit = lfs->open(layer_name.back().c_str(), O_RDWR | O_CREAT | O_TRUNC, S_IRWXU);
+    CommitArgs args(fcommit);
+    ((LSMTReadOnlyFile*)fdup)->commit(args);
+    fcommit->close();
+    fcommit = (IFile*)open_file_ro(layer_name.back().c_str());
+    verify_file((IFileRO*)fcommit);
+    delete fcommit;
+    delete file;
+}
+
 TEST_F(FileTest3, stack_sparsefiles) {
     CleanUp();
     cout << "generating " << FLAGS_layers << " RO layers by randwrite()" << endl;


### PR DESCRIPTION
**What this PR does / why we need it**:
  
- close_seal() Method can also convert a LSMTSparseFile as a LSMTReadOnlyFile with 'sparse_rw' tag. Users should be careful to compact such files before uploading them. :D
- And also, a compacted LSMTReadonlyFile shouldn't be committed twice. This PR adds some format check for it.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

https://github.com/containerd/overlaybd/discussions/216

**Please check the following list**:
- [x]  Does the affected code have corresponding tests, e.g. unit test, E2E test?
- [ ]  Does this change require a documentation update?
- [ ]  Does this introduce breaking changes that would require an announcement or bumping the major version?
- [ ]  Do all new files have an appropriate license header?

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues directly to https://github.com/containerd/overlaybd/blob/main/MAINTAINERS. -->
