### PR TITLE
fix all sign-compare warnings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,8 +17,8 @@ set(EXECUTABLE_OUTPUT_PATH "${CMAKE_SOURCE_DIR}/build/output")
 
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_CURRENT_SOURCE_DIR}/CMake")
 
-set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fpic")
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fpic")
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fpic -Wall -Werror=sign-compare")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fpic -Wall -Werror=sign-compare")
 
 if (${ARCH} STREQUAL aarch64)
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fsigned-char")

--- a/src/bk_download.cpp
+++ b/src/bk_download.cpp
@@ -55,7 +55,7 @@ std::string sha256sum(const char *fn) {
     SHA256_Init(&ctx);
     __attribute__((aligned(ALIGNMENT))) char buffer[65536];
     unsigned char sha[32];
-    int recv = 0;
+    ssize_t recv = 0;
     for (off_t offset = 0; offset < stat.st_size; offset += BUFFERSIZE) {
         recv = pread(fd, &buffer, BUFFERSIZE, offset);
         if (recv < 0) {

--- a/src/overlaybd/cache/download_cache/download_cache.cpp
+++ b/src/overlaybd/cache/download_cache/download_cache.cpp
@@ -226,13 +226,13 @@ again:
         read = m_file->preadv(buffer.iovec(), buffer.iovcnt(), r_offset);
     }
 
-    if (read != r_count) {
+    if (read != (ssize_t)r_count) {
         LOG_ERRNO_RETURN(0, -1, "src file read failed, read: `, expect: `, size: `, offset: `",
                          read, r_count, m_size, r_offset);
     }
 
     auto write = m_local_file->pwritev(buffer.iovec(), buffer.iovcnt(), r_offset);
-    if (write != r_count) {
+    if (write != (ssize_t)r_count) {
         LOG_ERRNO_RETURN(0, -1, "local file write failed, write: `, expect: `, size: `, offset: `",
                          write, r_count, m_size, r_offset);
     }

--- a/src/overlaybd/cache/ocf_cache/CMakeLists.txt
+++ b/src/overlaybd/cache/ocf_cache/CMakeLists.txt
@@ -12,6 +12,7 @@ file(GLOB_RECURSE src_ocf ocf/src/*.c)
 add_library(ocf_lib STATIC ${src_ocf})
 target_include_directories(ocf_lib PUBLIC include/ ease_bindings/env/)
 target_link_libraries(ocf_lib ocf_env_lib z)
+target_compile_options(ocf_lib PUBLIC -Wno-sign-compare)
 
 # ocf_cache_lib
 file(GLOB src_ocf_cache ocf_cache.cpp ocf_namespace.cpp ease_bindings/*.cpp)

--- a/src/overlaybd/cache/ocf_cache/ocf_cache.cpp
+++ b/src/overlaybd/cache/ocf_cache/ocf_cache.cpp
@@ -191,7 +191,7 @@ int OcfCachedFile::fadvise(off_t offset, off_t len, int advice) {
     if (advice == POSIX_FADV_WILLNEED) {
         void *buf = m_fs->get_io_alloc()->alloc(len);
         DEFER(m_fs->get_io_alloc()->dealloc(buf));
-        int ret = pread(buf, len, offset);
+        auto ret = pread(buf, len, offset);
         if (ret < 0) {
             LOG_ERROR_RETURN(0, -1, "prefetch read failed");
         }

--- a/src/overlaybd/extfs/extfs.cpp
+++ b/src/overlaybd/extfs/extfs.cpp
@@ -813,7 +813,7 @@ int do_ext2fs_access(ext2_filsys fs, const char *path, int mode) {
     mode_t perms = inode.i_mode & 0777;
     if ((mode & W_OK) && (inode.i_flags & EXT2_IMMUTABLE_FL))
         return -EACCES;
-    if ((mode & perms) == mode)
+    if ((mode & perms) == (mode_t)mode)
         return 0;
     return -EACCES;
 }
@@ -996,7 +996,7 @@ int do_ext2fs_fiemap(ext2_filsys fs, ext2_ino_t ino, struct photon::fs::fiemap* 
     if (ret) return parse_extfs_error(fs, ino, ret);
     map->fm_mapped_extents = blocks.size();
     photon::fs::fiemap_extent *ext_buf = &map->fm_extents[0];
-    for (int i = 0; i < blocks.size(); i++) {
+    for (uint32_t i = 0; i < blocks.size(); i++) {
         LOG_DEBUG("find block ` `", blocks[i].first * fs->blocksize, blocks[i].second * fs->blocksize);
         ext_buf[i].fe_physical = blocks[i].first * fs->blocksize;
         ext_buf[i].fe_length = blocks[i].second * fs->blocksize;

--- a/src/overlaybd/lsmt/file.cpp
+++ b/src/overlaybd/lsmt/file.cpp
@@ -180,7 +180,7 @@ struct HeaderTrailer {
 
 class LSMTReadOnlyFile;
 static LSMTReadOnlyFile *open_file_ro(IFile *file, bool ownership, bool reserve_tag);
-static HeaderTrailer *verify_ht(IFile *file, char *buf, bool is_trailer = false, size_t st_size = -1);
+static HeaderTrailer *verify_ht(IFile *file, char *buf, bool is_trailer = false, ssize_t st_size = -1);
 
 static const uint32_t ALIGNMENT = 512; // same as trim block size.
 static const uint32_t ALIGNMENT4K = 4096;
@@ -1111,7 +1111,7 @@ public:
         LOG_DEBUG("write index to dest_file `, offset: `, size: `*`", dest_file, index_offset,
                   index_size, sizeof(SegmentMapping));
         auto nwrite = dest_file->write(&compact_index[0], index_size * sizeof(SegmentMapping));
-        if (nwrite != (ssize_t)index_size * sizeof(SegmentMapping)) {
+        if (nwrite != (ssize_t)(index_size * sizeof(SegmentMapping))) {
             LOG_ERRNO_RETURN(0, -1, "write index failed");
         }
         nindex = index_size;
@@ -1145,7 +1145,7 @@ public:
     }
 };
 
-static HeaderTrailer *verify_ht(IFile *file, char *buf, bool is_trailer, size_t st_size) {
+static HeaderTrailer *verify_ht(IFile *file, char *buf, bool is_trailer, ssize_t st_size) {
     if (file == nullptr) {
         LOG_ERRNO_RETURN(0, nullptr, "invalid file ptr (null).");
     }

--- a/src/overlaybd/registryfs/registryfs.cpp
+++ b/src/overlaybd/registryfs/registryfs.cpp
@@ -403,7 +403,7 @@ public:
     again:
         photon::net::IOVWriter container(iov, iovcnt);
         auto count = container.sum();
-        if ((ssize_t)count + offset > filesize)
+        if (count + offset > filesize)
             count = filesize - offset;
         LOG_DEBUG("pulling blob from docker registry: ", VALUE(m_url), VALUE(offset), VALUE(count));
 

--- a/src/overlaybd/registryfs/registryfs_v2.cpp
+++ b/src/overlaybd/registryfs/registryfs_v2.cpp
@@ -356,7 +356,7 @@ public:
     again:
         iovector_view view((struct iovec*)iov, iovcnt);
         auto count = view.sum();
-        if ((ssize_t)count + offset > filesize)
+        if (count + offset > filesize)
             count = filesize - offset;
         LOG_DEBUG("pulling blob from registry: ", VALUE(m_url), VALUE(offset), VALUE(count));
 

--- a/src/overlaybd/tar/libtar.cpp
+++ b/src/overlaybd/tar/libtar.cpp
@@ -207,7 +207,7 @@ int UnTar::extract_regfile_meta_only(const char *filename) {
     fout->fallocate(0, 0, size);
     struct photon::fs::fiemap_t<8192> fie(0, size);
     fout->fiemap(&fie);
-    for (int i = 0; i < fie.fm_mapped_extents; i++) {
+    for (uint32_t i = 0; i < fie.fm_mapped_extents; i++) {
         LSMT::RemoteMapping lba;
         lba.offset = fie.fm_extents[i].fe_physical;
         lba.count = fie.fm_extents[i].fe_length;
@@ -252,11 +252,11 @@ int UnTar::extract_regfile(const char *filename) {
             rsz = left & fs_blockmask;
         else
             rsz = (left & ~T_BLOCKMASK) ? (left & T_BLOCKMASK) + T_BLOCKSIZE : (left & T_BLOCKMASK);
-        if (file->read(buf, rsz) != rsz) {
+        if (file->read(buf, rsz) != (ssize_t)rsz) {
             LOG_ERRNO_RETURN(0, -1, "failed to read block");
         }
         size_t wsz = (left < rsz) ? left : rsz;
-        if (fout->pwrite(buf, wsz, pos) != wsz) {
+        if (fout->pwrite(buf, wsz, pos) != (ssize_t)wsz) {
             LOG_ERRNO_RETURN(0, -1, "failed to write file");
         }
         pos += wsz;

--- a/src/overlaybd/tar/tar_file.cpp
+++ b/src/overlaybd/tar/tar_file.cpp
@@ -256,7 +256,7 @@ private:
     }
 
     std::string format_pax_record(const std::string &key, const std::string &value) {
-        int size = key.length() + value.length() + 3; // padding for ' ', '=' and '\n'
+        size_t size = key.length() + value.length() + 3; // padding for ' ', '=' and '\n'
         size += to_string(size).length();
         std::string record = to_string(size) + " " + key + "=" + value + "\n";
         if (record.length() != size) {

--- a/src/overlaybd/zfile/compressor.cpp
+++ b/src/overlaybd/zfile/compressor.cpp
@@ -91,7 +91,7 @@ public:
         }
         off_t src_offset = 0, dst_offset = 0;
         int ret = 0;
-        for (ssize_t i = 0; i < n; i++) {
+        for (size_t i = 0; i < n; i++) {
             uncompressed_data[i] = ((unsigned char *)src + src_offset);
             compressed_data[i] = ((unsigned char *)dst + dst_offset);
             src_offset += src_chunk_len[i];
@@ -120,7 +120,7 @@ public:
         }
         off_t src_offset = 0, dst_offset = 0;
         int ret = 0;
-        for (ssize_t i = 0; i < n; i++) {
+        for (size_t i = 0; i < n; i++) {
             compressed_data[i] = ((unsigned char *)src + src_offset);
             uncompressed_data[i] = ((unsigned char *)dst + dst_offset);
             src_offset += src_chunk_len[i];
@@ -208,7 +208,7 @@ public:
             return ret;
         }
 #endif
-        for (ssize_t i = 0; i < nblock; i++) {
+        for (size_t i = 0; i < nblock; i++) {
             ret =
                 LZ4_compress_default((const char *)uncompressed_data[i], (char *)compressed_data[i],
                                      src_chunk_len[i], dst_buffer_capacity / nblock);
@@ -240,7 +240,7 @@ public:
             return ret;
         }
 #endif
-        for (ssize_t i = 0; i < n; i++) {
+        for (size_t i = 0; i < n; i++) {
             ret =
                 LZ4_decompress_safe((const char *)compressed_data[i], (char *)uncompressed_data[i],
                                     src_chunk_len[i], dst_buffer_capacity / n);
@@ -295,7 +295,7 @@ public:
                             size_t nblock) override {
 
         int ret = 0;
-        for (int i = 0; i < nblock; i++) {
+        for (size_t i = 0; i < nblock; i++) {
             ret = compress(uncompressed_data[i], src_chunk_len[i], compressed_data[i],
                            dst_buffer_capacity / nblock);
             if (ret < 0) {
@@ -311,7 +311,7 @@ public:
                               size_t dst_buffer_capacity, size_t nblock) override {
 
         int ret = 0;
-        for (ssize_t i = 0; i < nblock; i++) {
+        for (size_t i = 0; i < nblock; i++) {
             ret = decompress((const unsigned char *)uncompressed_data[i], src_chunk_len[i],
                              compressed_data[i], dst_buffer_capacity / nblock);
 

--- a/src/overlaybd/zfile/lz4/lz4-qat.c
+++ b/src/overlaybd/zfile/lz4/lz4-qat.c
@@ -25,7 +25,7 @@ LZ4LIB_API int LZ4_compress_qat(LZ4_qat_param *pQat, const unsigned char *const 
                                 size_t src_chunk_len[], unsigned char *compressed_data[],
                                 size_t dst_chunk_len[], size_t n) {
     int32_t status = 0;
-    for (ssize_t i = 0; i < n; i++) {
+    for (size_t i = 0; i < n; i++) {
         int ret = LZ4_compress_default((const char *)raw_data[i], (char *)compressed_data[i],
                                         src_chunk_len[i], 4096);
         dst_chunk_len[i] = ret;
@@ -37,7 +37,7 @@ LZ4LIB_API int LZ4_decompress_qat(LZ4_qat_param *pQat, const unsigned char *cons
                                 size_t src_chunk_len[], unsigned char *decompressed_data[],
                                 size_t dst_chunk_len[], size_t n){
     int32_t status = 0;
-    for (ssize_t i = 0; i < n; i++) {
+    for (size_t i = 0; i < n; i++) {
         int ret = LZ4_decompress_safe((const char *)raw_data[i], (char *)decompressed_data[i],
                                         src_chunk_len[i], 4096);
         dst_chunk_len[i] = ret;


### PR DESCRIPTION
**What this PR does / why we need it**:
- fix useless pread return value check in zfile jump table loading
- fix other sign-cmpare warnings

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes  https://github.com/containerd/accelerated-container-image/issues/205

**Please check the following list**:
- [ ]  Does the affected code have corresponding tests, e.g. unit test, E2E test?
- [ ]  Does this change require a documentation update?
- [ ]  Does this introduce breaking changes that would require an announcement or bumping the major version?
- [ ]  Do all new files have an appropriate license header?

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues directly to https://github.com/containerd/overlaybd/blob/main/MAINTAINERS. -->
