### PR TITLE
Add '--verify' flag in overlaybd-zfile

### DIFF
--- a/src/overlaybd/zfile/zfile.h
+++ b/src/overlaybd/zfile/zfile.h
@@ -27,6 +27,9 @@ extern "C" int zfile_compress(photon::fs::IFile *src_file, photon::fs::IFile *ds
 
 extern "C" int zfile_decompress(photon::fs::IFile *src_file, photon::fs::IFile *dst_file);
 
+extern "C" int zfile_validation_check(photon::fs::IFile *src_file);
+
+
 extern "C" photon::fs::IFile *new_zfile_builder(photon::fs::IFile *file,
                                                 const CompressArgs *args = nullptr,
                                                 bool ownership = false);

--- a/src/tools/overlaybd-zfile.cpp
+++ b/src/tools/overlaybd-zfile.cpp
@@ -31,6 +31,7 @@
 #include <unistd.h>
 #include <photon/photon.h>
 #include "CLI11.hpp"
+#include "photon/fs/filesystem.h"
 
 using namespace std;
 using namespace photon::fs;
@@ -38,11 +39,21 @@ using namespace ZFile;
 
 IFileSystem *lfs = nullptr;
 
+int verify_crc(IFile* src_file) {
+
+    if (!is_zfile(src_file)) {
+        fprintf(stderr, "format error! <source_file> should be a zfile.\n");
+        exit(-1);
+    }
+    return zfile_validation_check(src_file);
+}
+
 int main(int argc, char **argv) {
 
     bool rm_old = false;
     bool tar = false;
     bool extract = false;
+    bool verify = false;
     std::string fn_src, fn_dst;
     std::string algorithm;
     int block_size;
@@ -50,6 +61,7 @@ int main(int argc, char **argv) {
     CLI::App app{"this is a zfile tool to create/extract zfile"};
     app.add_flag("-t", tar, "wrapper with tar")->default_val(false);
     app.add_flag("-x", extract, "extract zfile")->default_val(false);
+    app.add_flag("--verify", verify, "verify checksum of {source_file}")->default_val(false);
     app.add_flag("-f", rm_old, "force compress. unlink exist")->default_val(false);
     app.add_option("--algorithm", algorithm, "compress algorithm, [lz4|zstd]")->default_str("lz4");
     app.add_option(
@@ -60,11 +72,25 @@ int main(int argc, char **argv) {
         ->type_name("FILEPATH")
         ->check(CLI::ExistingFile)
         ->required();
-    app.add_option("target_file", fn_dst, "target file path")->type_name("FILEPATH")->required();
+    app.add_option("target_file", fn_dst, "target file path")->type_name("FILEPATH");//->required();
     CLI11_PARSE(app, argc, argv);
 
     set_log_output_level(1);
     photon::init(photon::INIT_EVENT_DEFAULT, photon::INIT_IO_DEFAULT);
+    lfs = new_localfs_adaptor();
+    if (verify) {
+        auto file = lfs->open(fn_src.c_str(), O_RDONLY);
+        if (!file) {
+            fprintf(stderr, "failed to open file %s\n", fn_src.c_str());
+            exit(-1);
+        }
+        if (verify_crc(file)!=0) {
+            printf("%s is not a valid zfile blob or checksum can't be found.\n", fn_src.c_str());
+            return -1;
+        }
+        printf("%s is a valid zfile blob.\n", fn_src.c_str());
+        return 0;
+    }
 
     CompressOptions opt;
     opt.verify = 1;
@@ -78,7 +104,6 @@ int main(int argc, char **argv) {
         fprintf(stderr, "invalid '--bs' parameters.\nj");
         exit(-1);
     }
-    lfs = new_localfs_adaptor();
     if (rm_old) {
         lfs->unlink(fn_dst.c_str());
     }


### PR DESCRIPTION
overlaybd-zfile --verify <file> will check if the specified file is a valid zfile with checksum.

**What this PR does / why we need it**:

https://github.com/containerd/accelerated-container-image/issues/196

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Please check the following list**:
- [x]  Does the affected code have corresponding tests, e.g. unit test, E2E test?
- [ ]  Does this change require a documentation update?
- [ ]  Does this introduce breaking changes that would require an announcement or bumping the major version?
- [ ]  Do all new files have an appropriate license header?

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues directly to https://github.com/containerd/overlaybd/blob/main/MAINTAINERS. -->
