### PR TITLE
fix bug in overlaybd-commit for fastoci

### DIFF
--- a/src/tools/overlaybd-commit.cpp
+++ b/src/tools/overlaybd-commit.cpp
@@ -88,7 +88,7 @@ int main(int argc, char **argv) {
             index_file_path, data_file_path);
         IFile* findex = open_file(lfs, index_file_path.c_str(), O_RDONLY, 0);
         fin = open_warpfile_rw(findex, fdata, nullptr, true);
-    } if (commit_sealed) {
+    } else if (commit_sealed) {
         fin = (IFileRW*)open_file_ro(fdata, true);
         commit_file_path = index_file_path; // the second param is for commit path
     } else {


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixed branch bug in overlaybd-commit. In fastoci conversion, it will go to a wrong branch because missing of `else`.
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Please check the following list**:
- [ ]  Does the affected code have corresponding tests, e.g. unit test, E2E test?
- [ ]  Does this change require a documentation update?
- [ ]  Does this introduce breaking changes that would require an announcement or bumping the major version?
- [ ]  Do all new files have an appropriate license header?

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues directly to https://github.com/containerd/overlaybd/blob/main/MAINTAINERS. -->
