### PR TITLE
Add error status in ZFile::BlockReader

### DIFF
--- a/src/overlaybd/zfile/compressor.cpp
+++ b/src/overlaybd/zfile/compressor.cpp
@@ -90,7 +90,6 @@ public:
             LOG_ERROR_RETURN(ENOBUFS, -1, "dst_len should be greater than `", max_dst_size - 1);
         }
         off_t src_offset = 0, dst_offset = 0;
-        int ret = 0;
         for (size_t i = 0; i < n; i++) {
             uncompressed_data[i] = ((unsigned char *)src + src_offset);
             compressed_data[i] = ((unsigned char *)dst + dst_offset);
@@ -119,7 +118,6 @@ public:
                              dst_buffer_capacity / n, src_blk_size);
         }
         off_t src_offset = 0, dst_offset = 0;
-        int ret = 0;
         for (size_t i = 0; i < n; i++) {
             compressed_data[i] = ((unsigned char *)src + src_offset);
             uncompressed_data[i] = ((unsigned char *)dst + dst_offset);


### PR DESCRIPTION
**What this PR does / why we need it**:

Add return value check for Zfile::BlockReader to avoid getting invalid data in ZFile::pread.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Please check the following list**:
- [ ]  Does the affected code have corresponding tests, e.g. unit test, E2E test?
- [ ]  Does this change require a documentation update?
- [ ]  Does this introduce breaking changes that would require an announcement or bumping the major version?
- [ ]  Do all new files have an appropriate license header?

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues directly to https://github.com/containerd/overlaybd/blob/main/MAINTAINERS. -->
