### PR TITLE
fix for zfile and tools

### DIFF
--- a/src/tools/CMakeLists.txt
+++ b/src/tools/CMakeLists.txt
@@ -5,6 +5,7 @@ target_link_libraries(overlaybd-commit photon_static overlaybd_lib)
 add_executable(overlaybd-create overlaybd-create.cpp)
 target_include_directories(overlaybd-create PUBLIC ${PHOTON_INCLUDE_DIR})
 target_link_libraries(overlaybd-create photon_static overlaybd_lib)
+set_target_properties(overlaybd-create PROPERTIES INSTALL_RPATH "/opt/overlaybd/lib")
 
 add_executable(overlaybd-zfile overlaybd-zfile.cpp)
 target_include_directories(overlaybd-zfile PUBLIC ${PHOTON_INCLUDE_DIR})
@@ -13,7 +14,6 @@ target_link_libraries(overlaybd-zfile photon_static overlaybd_lib)
 add_executable(overlaybd-apply overlaybd-apply.cpp)
 target_include_directories(overlaybd-apply PUBLIC ${PHOTON_INCLUDE_DIR} ${rapidjson_SOURCE_DIR}/include)
 target_link_libraries(overlaybd-apply photon_static overlaybd_lib overlaybd_image_lib)
-
 set_target_properties(overlaybd-apply PROPERTIES INSTALL_RPATH "/opt/overlaybd/lib")
 
 install(TARGETS

--- a/src/tools/overlaybd-apply.cpp
+++ b/src/tools/overlaybd-apply.cpp
@@ -121,6 +121,7 @@ int main(int argc, char **argv) {
 
     set_log_output_level(verbose ? 0 : 1);
     photon::init(photon::INIT_EVENT_DEFAULT, photon::INIT_IO_DEFAULT);
+    DEFER({photon::fini();});
 
     photon::fs::IFile *imgfile = nullptr;
     if (raw) {

--- a/src/tools/overlaybd-commit.cpp
+++ b/src/tools/overlaybd-commit.cpp
@@ -56,6 +56,7 @@ int main(int argc, char **argv) {
     bool compress_zfile = false;
     bool build_fastoci = false;
     bool tar = false, rm_old = false, seal = false, commit_sealed = false;
+    bool verbose = false;
 
     CLI::App app{"this is overlaybd-commit"};
     app.add_option("-m", commit_msg, "add some custom message if needed");
@@ -74,10 +75,12 @@ int main(int argc, char **argv) {
     app.add_option("commit_file", commit_file_path, "commit file path")->type_name("FILEPATH");
     app.add_flag("--seal", seal, "seal only, data_file is output itself")->default_val(false);
     app.add_flag("--commit_sealed", commit_sealed, "commit sealed, index_file is output")->default_val(false);
+    app.add_flag("--verbose", verbose, "output debug info")->default_val(false);
     CLI11_PARSE(app, argc, argv);
 
-    set_log_output_level(1);
+    set_log_output_level(verbose ? 0 : 1);
     photon::init(photon::INIT_EVENT_DEFAULT, photon::INIT_IO_DEFAULT);
+    DEFER({photon::fini();});
 
     IFileSystem *lfs = new_localfs_adaptor();
 
@@ -173,6 +176,6 @@ int main(int argc, char **argv) {
     delete zfile_builder;
     delete fout;
     delete fin;
-    printf("lsmt_commit has committed files SUCCESSFULLY\n");
+    printf("overlaybd-commit has committed files SUCCESSFULLY\n");
     return ret;
 }

--- a/src/tools/overlaybd-create.cpp
+++ b/src/tools/overlaybd-create.cpp
@@ -52,6 +52,7 @@ int main(int argc, char **argv) {
     std::string data_file_path, index_file_path, warp_index_path;
     bool build_fastoci = false;
     bool mkfs = false;
+    bool verbose = false;
 
     CLI::App app{"this is overlaybd-create"};
     app.add_option("-u", parent_uuid, "parent uuid");
@@ -61,10 +62,12 @@ int main(int argc, char **argv) {
     app.add_option("data_file", data_file_path, "data file path")->type_name("FILEPATH")->required();
     app.add_option("index_file", index_file_path, "index file path")->type_name("FILEPATH")->required();
     app.add_option("vsize", vsize, "virtual size(GB)")->type_name("INT")->check(CLI::PositiveNumber)->required();
+    app.add_flag("--verbose", verbose, "output debug info")->default_val(false);
     CLI11_PARSE(app, argc, argv);
 
-
+    set_log_output_level(verbose ? 0 : 1);
     photon::init(photon::INIT_EVENT_DEFAULT, photon::INIT_IO_DEFAULT);
+    DEFER({photon::fini();});
 
     vsize *= 1024 * 1024 * 1024;
     const auto flag = O_RDWR | O_EXCL | O_CREAT;
@@ -100,6 +103,6 @@ int main(int argc, char **argv) {
     delete file;
     delete fdata;
     delete findex;
-    printf("lsmt_create has created files SUCCESSFULLY\n");
+    printf("overlaybd-create has created files SUCCESSFULLY\n");
     return 0;
 }

--- a/src/tools/overlaybd-zfile.cpp
+++ b/src/tools/overlaybd-zfile.cpp
@@ -57,6 +57,7 @@ int main(int argc, char **argv) {
     std::string fn_src, fn_dst;
     std::string algorithm;
     int block_size;
+    bool verbose = false;
 
     CLI::App app{"this is a zfile tool to create/extract zfile"};
     app.add_flag("-t", tar, "wrapper with tar")->default_val(false);
@@ -72,11 +73,14 @@ int main(int argc, char **argv) {
         ->type_name("FILEPATH")
         ->check(CLI::ExistingFile)
         ->required();
-    app.add_option("target_file", fn_dst, "target file path")->type_name("FILEPATH");//->required();
+    app.add_option("target_file", fn_dst, "target file path")->type_name("FILEPATH");
+    app.add_flag("--verbose", verbose, "output debug info")->default_val(false);
     CLI11_PARSE(app, argc, argv);
 
-    set_log_output_level(1);
+    set_log_output_level(verbose ? 0 : 1);
     photon::init(photon::INIT_EVENT_DEFAULT, photon::INIT_IO_DEFAULT);
+    DEFER({photon::fini();});
+
     lfs = new_localfs_adaptor();
     if (verify) {
         auto file = lfs->open(fn_src.c_str(), O_RDONLY);


### PR DESCRIPTION
**What this PR does / why we need it**:
- zfile: always try evict after loading jump table failed
- tools: add verbose option and photon::fini()
- 
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Please check the following list**:
- [ ]  Does the affected code have corresponding tests, e.g. unit test, E2E test?
- [ ]  Does this change require a documentation update?
- [ ]  Does this introduce breaking changes that would require an announcement or bumping the major version?
- [ ]  Do all new files have an appropriate license header?

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues directly to https://github.com/containerd/overlaybd/blob/main/MAINTAINERS. -->
