### PR TITLE
fix double free & enhence p2p failover

### DIFF
--- a/src/image_service.h
+++ b/src/image_service.h
@@ -29,6 +29,7 @@ using namespace photon::fs;
 struct GlobalFs {
     IFileSystem *remote_fs = nullptr;
     IFileSystem *srcfs = nullptr;
+    IFileSystem *cached_fs = nullptr;
     Cache::GzipCachedFs *gzcache_fs = nullptr;
 
     // ocf cache only

--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -4,16 +4,16 @@ link_directories($ENV{GFLAGS}/lib)
 include_directories($ENV{GTEST}/googletest/include)
 link_directories($ENV{GTEST}/lib)
 
-add_executable(curl_test test.cpp)
-target_include_directories(curl_test PUBLIC
+add_executable(image_service_test image_service_test.cpp)
+target_include_directories(image_service_test PUBLIC
     ${PHOTON_INCLUDE_DIR}
     ${rapidjson_SOURCE_DIR}/include
 )
-target_link_libraries(curl_test gtest gtest_main gflags pthread photon_static overlaybd_lib overlaybd_image_lib)
+target_link_libraries(image_service_test gtest gtest_main gflags pthread photon_static overlaybd_lib overlaybd_image_lib)
 
 add_test(
-    NAME curl_test
-    COMMAND ${EXECUTABLE_OUTPUT_PATH}/curl_test
+    NAME image_service_test
+    COMMAND ${EXECUTABLE_OUTPUT_PATH}/image_service_test
 )
 
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Before this change:
- if `p2pConfig().enable() == true`, then `srcfs` will equal `remote_fs`, which leads to double free.
- if `check_accelerate_url` failed, it doesn't use any cache, this will cause all data to back to the source, resulting in reduced efficiency.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Please check the following list**:
- [x]  Does the affected code have corresponding tests, e.g. unit test, E2E test?
- [x]  Does this change require a documentation update?
- [x]  Does this introduce breaking changes that would require an announcement or bumping the major version?
- [x]  Do all new files have an appropriate license header?

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues directly to https://github.com/containerd/overlaybd/blob/main/MAINTAINERS. -->
