### PR TITLE
ensure overlaybd-apply exit normally

### DIFF
--- a/CMake/Findrapidjson.cmake
+++ b/CMake/Findrapidjson.cmake
@@ -2,6 +2,7 @@ FetchContent_Declare(
   rapidjson
   GIT_REPOSITORY https://github.com/Tencent/rapidjson.git
   GIT_TAG 80b6d1c83402a5785c486603c5611923159d0894
+  GIT_SUBMODULES ""
 )
 FetchContent_GetProperties(rapidjson)
 if (NOT rapidjson_POPULATED)

--- a/src/image_service.cpp
+++ b/src/image_service.cpp
@@ -483,8 +483,10 @@ ImageService::~ImageService() {
     delete global_fs.media_file;
     delete global_fs.namespace_fs;
     delete global_fs.cached_fs;
+    delete global_fs.gzcache_fs;
     delete global_fs.srcfs;
     delete global_fs.io_alloc;
+    delete exporter;
     LOG_INFO("image service is fully stopped");
 }
 

--- a/src/overlaybd/cache/gzip_cache/cached_fs.h
+++ b/src/overlaybd/cache/gzip_cache/cached_fs.h
@@ -19,6 +19,7 @@ namespace Cache {
 
 class GzipCachedFs {
 public:
+    virtual ~GzipCachedFs() {}
     virtual photon::fs::IFile *open_cached_gzip_file(photon::fs::IFile *file, const char *file_name) = 0;
 };
 GzipCachedFs *new_gzip_cached_fs(photon::fs::IFileSystem *mediaFs, uint64_t refillUnit,


### PR DESCRIPTION
**What this PR does / why we need it**:
ensure overlaybd-apply exit normally: fix destruction of image service and gzip cache fs.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes https://github.com/containerd/accelerated-container-image/issues/212

**Please check the following list**:
- [ ]  Does the affected code have corresponding tests, e.g. unit test, E2E test?
- [ ]  Does this change require a documentation update?
- [ ]  Does this introduce breaking changes that would require an announcement or bumping the major version?
- [ ]  Do all new files have an appropriate license header?

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues directly to https://github.com/containerd/overlaybd/blob/main/MAINTAINERS. -->
