### PR TITLE
[Feat] A stand-alone tool of fastoci:

### DIFF
--- a/src/overlaybd/tar/libtar.h
+++ b/src/overlaybd/tar/libtar.h
@@ -160,7 +160,7 @@ public:
     char *get_pathname();
     char *get_linkname();
     size_t get_size();
-    int read_header();
+    int read_header(photon::fs::IFile *dump = nullptr);
     bool has_pax_header() {
         return pax != nullptr;
     }
@@ -176,23 +176,26 @@ private:
     char *th_linkname = nullptr;
     PaxHeader *pax = nullptr;
 
-    int read_header_internal();
-    int read_sepcial_file(char *&buf);
+    int read_header_internal(photon::fs::IFile *dump = nullptr);
+    int read_sepcial_file(char *&buf, photon::fs::IFile *dump = nullptr);
 };
 
 class UnTar : public TarCore {
 public:
-    UnTar(photon::fs::IFile *file, photon::fs::IFileSystem *fs, int options,
+    UnTar(photon::fs::IFile *src_file, photon::fs::IFileSystem *target_fs, int options,
         uint64_t fs_blocksize = FS_BLOCKSIZE, photon::fs::IFile *bf = nullptr,
-        bool meta_only = false)
-        : TarCore(file, options, fs_blocksize), fs(fs), fs_base_file(bf), meta_only(meta_only) {}
+        bool meta_only = false, bool from_tar_idx = false)
+        : TarCore(src_file, options, fs_blocksize), fs(target_fs),
+            fs_base_file(bf), meta_only(meta_only), from_tar_idx(from_tar_idx){}
 
     int extract_all();
+    ssize_t dump_tar_headers(photon::fs::IFile* file);
 
 private:
     photon::fs::IFileSystem *fs = nullptr; // target
     photon::fs::IFile *fs_base_file = nullptr;
     bool meta_only;
+    bool from_tar_idx;
     std::set<std::string> unpackedPaths;
     std::list<std::pair<std::string, int>> dirs; // <path, utime>
 

--- a/src/overlaybd/tar/test/CMakeLists.txt
+++ b/src/overlaybd/tar/test/CMakeLists.txt
@@ -6,10 +6,10 @@ link_directories($ENV{GTEST}/lib)
 
 add_executable(untar_test test.cpp)
 target_include_directories(untar_test PUBLIC ${PHOTON_INCLUDE_DIR})
-target_link_libraries(untar_test gtest gtest_main pthread photon_static tar_lib)
+target_link_libraries(untar_test gtest gtest_main pthread photon_static
+  tar_lib extfs_lib lsmt_lib)
 
 add_test(
   NAME untar_test
   COMMAND ${EXECUTABLE_OUTPUT_PATH}/untar_test
 )
-

--- a/src/overlaybd/tar/test/test.cpp
+++ b/src/overlaybd/tar/test/test.cpp
@@ -14,39 +14,57 @@
    limitations under the License.
 */
 
+#include <cstring>
 #include <gtest/gtest.h>
 #include <fcntl.h>
 #include <photon/photon.h>
 #include <photon/fs/localfs.h>
 #include <photon/fs/subfs.h>
 #include <photon/common/alog.h>
+#include <vector>
+#include "../../extfs/extfs.h"
+#include "../../lsmt/file.h"
 #include "../libtar.h"
 #include "../tar_file.cpp"
 
+
 #define FILE_SIZE (2 * 1024 * 1024)
+#define IMAGE_SIZE 512UL<<20
 class TarTest : public ::testing::Test {
 protected:
-    static void SetUpTestSuite() {
+    virtual void SetUp() override{
         fs = photon::fs::new_localfs_adaptor();
-        std::string base = "/tmp/tar_test";
+
         ASSERT_NE(nullptr, fs);
         if (fs->access(base.c_str(), 0) != 0) {
             auto ret = fs->mkdir(base.c_str(), 0755);
             ASSERT_EQ(0, ret);
         }
-        // download file
-        std::string cmd = "wget -q -O - https://github.com/containerd/overlaybd/archive/refs/tags/latest.tar.gz | gzip -d -c >" +
-                          base + "/latest.tar";
-        LOG_INFO(VALUE(cmd.c_str()));
-        auto ret = system(cmd.c_str());
-        ASSERT_EQ(0, ret);
+
         fs = photon::fs::new_subfs(fs, base.c_str(), true);
         ASSERT_NE(nullptr, fs);
     }
-    static void TearDownTestSuite() {
+    virtual void TearDown() override{
+        for (auto fn : filelist){
+            fs->unlink(fn.c_str());
+        }
         if (fs)
             delete fs;
     }
+
+    int download(const std::string &url) {
+        // download file
+        std::string cmd = "wget -q -O - " + url +" | gzip -d -c >" +
+                          base + "/latest.tar";
+        LOG_INFO(VALUE(cmd.c_str()));
+        auto ret = system(cmd.c_str());
+        if (ret != 0) {
+            LOG_ERRNO_RETURN(0, -1, "download failed: `", url.c_str());
+        }
+        return 0;
+    }
+
+
     int write_file(photon::fs::IFile *file) {
         std::string bb = "abcdefghijklmnopqrstuvwxyz0123456789abcdefghijklmnopqrstuvwxyz01";
         ssize_t size = 0;
@@ -67,11 +85,61 @@ protected:
         return 0;
     }
 
-    static photon::fs::IFileSystem *fs;
+    IFile *createDevice(const char *fn, IFile *target_file, size_t virtual_size = IMAGE_SIZE){
+        auto fn_idx = std::string(fn)+".idx";
+        auto fn_meta = std::string(fn)+".meta";
+        DEFER({
+            filelist.push_back(fn_idx);
+            filelist.push_back(fn_meta);
+        });
+        auto fmeta = fs->open(fn_idx.c_str(), O_RDWR | O_CREAT | O_TRUNC, S_IRWXU);
+        auto findex = fs->open(fn_meta.c_str(), O_RDWR | O_CREAT | O_TRUNC, S_IRWXU);
+        LSMT::WarpFileArgs args(findex, fmeta, target_file);
+        args.virtual_size = virtual_size;
+        return create_warpfile(args, false);
+    }
+
+    int do_verify(IFile *verify, IFile *test, off_t offset = 0, ssize_t count = -1) {
+
+        if (count == -1) {
+            count = verify->lseek(0, SEEK_END);
+            auto len = test->lseek(0, SEEK_END);
+            if (count != len) {
+                LOG_ERROR("check logical length failed");
+                return -1;
+            }
+        }
+        LOG_INFO("start verify, virtual size: `", count);
+
+        ssize_t LEN = 1UL<<20;
+        char vbuf[1UL<<20], tbuf[1UL<<20];
+        for (off_t i = 0; i < count; i+=LEN) {
+            // LOG_INFO("`", i);
+            auto ret_v = verify->pread(vbuf, LEN, i);
+            auto ret_t = test->pread(tbuf, LEN, i);
+            if (ret_v == -1 || ret_t == -1) {
+                LOG_ERROR_RETURN(0, -1, "pread(`,`) failed. (ret_v: `, ret_t: `)",
+                    i, LEN, ret_v, ret_v);
+            }
+            if (ret_v != ret_t) {
+                LOG_ERROR_RETURN(0, -1, "compare pread(`,`) return code failed. ret:` / `(expected)",
+                    i, LEN, ret_t, ret_v);
+            }
+            if (memcmp(vbuf, tbuf, ret_v)!= 0){
+                LOG_ERROR_RETURN(0, -1, "compare pread(`,`) buffer failed.", i, LEN);
+            }
+        }
+        return 0;
+    }
+
+    std::string base = "/tmp/tar_test";
+    photon::fs::IFileSystem *fs;
+    std::vector<std::string> filelist;
 };
-photon::fs::IFileSystem *TarTest::fs = nullptr;
+// photon::fs::IFileSystem *TarTest::fs = nullptr;
 
 TEST_F(TarTest, untar) {
+    ASSERT_EQ(0, download("https://github.com/containerd/overlaybd/archive/refs/tags/latest.tar.gz"));
     auto tarf = fs->open("latest.tar", O_RDONLY, 0666);
     ASSERT_NE(nullptr, tarf);
     DEFER(delete tarf);
@@ -85,6 +153,51 @@ TEST_F(TarTest, untar) {
     auto ret = tar->extract_all();
     EXPECT_EQ(0, ret);
     delete tar;
+}
+
+TEST_F(TarTest, tar_meta) {
+    // set_log_output_level(0);
+    ASSERT_EQ(0, download("https://dadi-shared.oss-cn-beijing.aliyuncs.com/go1.17.6.linux-amd64.tar.gz"));
+    // ASSERT_EQ(0, download("https://github.com/containerd/overlaybd/archive/refs/tags/latest.tar.gz"));
+
+    auto src_file = fs->open("latest.tar", O_RDONLY, 0666);
+    ASSERT_NE(nullptr, src_file);
+    DEFER(delete src_file);
+    auto verify_dev = createDevice("verify", src_file);
+    make_extfs(verify_dev);
+    auto verify_ext4fs = new_extfs(verify_dev, false);
+    auto verifyfs = new_subfs(verify_ext4fs, "/", true);
+    auto fastoci_verify = new UnTar(src_file, verifyfs, 0, 4096, verify_dev, true);
+    ASSERT_EQ(0, fastoci_verify->extract_all());
+    verify_ext4fs->sync();
+    delete fastoci_verify;
+    delete verifyfs;
+
+    src_file->lseek(0, 0);
+
+    auto tar_idx = fs->open("latest.tar.meta", O_TRUNC | O_CREAT | O_RDWR, 0644);
+    auto imgfile = createDevice("mock", src_file);
+    DEFER(delete imgfile;);
+    auto tar = new UnTar(src_file, nullptr, 0, 4096, nullptr, false);
+    auto obj_count = tar->dump_tar_headers(tar_idx);
+    EXPECT_NE(-1, obj_count);
+    LOG_INFO("objects count: `", obj_count);
+    tar_idx->lseek(0,0);
+
+    make_extfs(imgfile);
+    auto extfs = new_extfs(imgfile, false);
+    auto target = new_subfs(extfs, "/", true);
+    auto fastoci_mock = new UnTar(tar_idx, target, TAR_IGNORE_CRC, 4096, imgfile, true, true);
+    auto ret = fastoci_mock->extract_all();
+    delete fastoci_mock;
+    delete target;
+
+    ASSERT_EQ(0, ret);
+    EXPECT_EQ(0, do_verify(verify_dev, imgfile));
+    delete tar_idx;
+    delete tar;
+
+    // EXPECT_EQ(0, ret);
 }
 
 TEST_F(TarTest, tar_header_check) {

--- a/src/tools/CMakeLists.txt
+++ b/src/tools/CMakeLists.txt
@@ -11,15 +11,22 @@ add_executable(overlaybd-zfile overlaybd-zfile.cpp)
 target_include_directories(overlaybd-zfile PUBLIC ${PHOTON_INCLUDE_DIR})
 target_link_libraries(overlaybd-zfile photon_static overlaybd_lib)
 
-add_executable(overlaybd-apply overlaybd-apply.cpp)
+add_executable(overlaybd-apply overlaybd-apply.cpp comm_func.cpp)
 target_include_directories(overlaybd-apply PUBLIC ${PHOTON_INCLUDE_DIR} ${rapidjson_SOURCE_DIR}/include)
 target_link_libraries(overlaybd-apply photon_static overlaybd_lib overlaybd_image_lib)
 set_target_properties(overlaybd-apply PROPERTIES INSTALL_RPATH "/opt/overlaybd/lib")
+
+add_executable(fastoci-apply fastoci-apply.cpp comm_func.cpp)
+target_include_directories(fastoci-apply PUBLIC ${PHOTON_INCLUDE_DIR} ${rapidjson_SOURCE_DIR}/include)
+target_link_libraries(fastoci-apply photon_static overlaybd_lib overlaybd_image_lib)
+set_target_properties(fastoci-apply PROPERTIES INSTALL_RPATH "/opt/overlaybd/lib")
+
 
 install(TARGETS
     overlaybd-commit
     overlaybd-create
     overlaybd-zfile
     overlaybd-apply
+    fastoci-apply
     DESTINATION /opt/overlaybd/bin
 )

--- a/src/tools/comm_func.cpp
+++ b/src/tools/comm_func.cpp
@@ -1,0 +1,80 @@
+/*
+   Copyright The Overlaybd Authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+#include "comm_func.h"
+#include "../overlaybd/tar/tar_file.h"
+#include <openssl/sha.h>
+#include <photon/fs/subfs.h>
+
+#include "../overlaybd/extfs/extfs.h"
+#include "../image_service.h"
+#include "../image_file.h"
+
+
+using namespace std;
+using namespace photon::fs;
+
+IFile *open_file(const char *fn, int flags, mode_t mode, IFileSystem *fs) {
+    IFile *file = nullptr;
+    if (fs) {
+        file = fs->open(fn, flags, mode);
+    } else {
+        file = open_localfile_adaptor(fn, flags, mode, 0);
+    }
+    if (!file) {
+        fprintf(stderr, "failed to open file '%s', %d: %s\n", fn, errno, strerror(errno));
+        exit(-1);
+    }
+    return file;
+}
+
+int create_overlaybd(const std::string &srv_config, const std::string &dev_config,
+    ImageService *&imgservice, photon::fs::IFile *&imgfile) {
+
+    imgservice = create_image_service(srv_config.c_str());
+    if (imgservice == nullptr) {
+        fprintf(stderr, "failed to create image service\n");
+        exit(-1);
+    }
+    imgfile = imgservice->create_image_file(dev_config.c_str());
+    if (imgfile == nullptr) {
+        fprintf(stderr, "failed to create image file\n");
+        exit(-1);
+    }
+    return 0;
+};
+
+photon::fs::IFileSystem *create_ext4fs(photon::fs::IFile *imgfile, bool mkfs,
+    bool enable_buffer, const char* root){
+    if (mkfs) {
+        if (make_extfs(imgfile) < 0) {
+            fprintf(stderr, "mkfs failed, %s\n", strerror(errno));
+            exit(-1);
+        }
+    }
+    // for now, buffer_file can't be used with fastoci
+    auto extfs = new_extfs(imgfile, enable_buffer);
+    if (!extfs) {
+        fprintf(stderr, "new extfs failed, %s\n", strerror(errno));
+        exit(-1);
+    }
+    auto target = new_subfs(extfs, root, true);
+    if (!target) {
+        fprintf(stderr, "new subfs failed, %s\n", strerror(errno));
+        exit(-1);
+    }
+    return target;
+}

--- a/src/tools/comm_func.h
+++ b/src/tools/comm_func.h
@@ -1,0 +1,97 @@
+/*
+   Copyright The Overlaybd Authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+#pragma once
+
+#include <stdlib.h>
+#include <stdio.h>
+#include <errno.h>
+#include <inttypes.h>
+#include <memory>
+#include <string>
+#include <unistd.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <fcntl.h>
+#include "../overlaybd/lsmt/file.h"
+#include "../overlaybd/zfile/zfile.h"
+#include "../image_service.h"
+#include "../image_file.h"
+#include <photon/common/alog.h>
+#include <photon/fs/localfs.h>
+#include <photon/common/uuid.h>
+#include <photon/photon.h>
+#include "CLI11.hpp"
+#include <openssl/sha.h>
+
+
+int generate_option(CLI::App &app);
+photon::fs::IFile *open_file(const char *fn, int flags, mode_t mode = 0, photon::fs::IFileSystem *fs = nullptr);
+
+int create_overlaybd(const std::string &srv_config, const std::string &dev_config,
+    ImageService *&, photon::fs::IFile *&);
+
+photon::fs::IFileSystem *create_ext4fs(photon::fs::IFile *imgfile, bool mkfs,
+    bool enable_buffer, const char* root);
+
+class SHA256CheckedFile: public VirtualReadOnlyFile {
+public:
+    IFile *m_file;
+    SHA256_CTX ctx = {0};
+    size_t total_read = 0;
+
+    SHA256CheckedFile(IFile *file): m_file(file) {
+        SHA256_Init(&ctx);
+    }
+    ~SHA256CheckedFile() {
+        delete m_file;
+    }
+    virtual IFileSystem *filesystem() override {
+        return nullptr;
+    }
+    ssize_t read(void *buf, size_t count) override {
+        auto rc = m_file->read(buf, count);
+        if (rc > 0 && SHA256_Update(&ctx, buf, rc) < 0) {
+            LOG_ERROR("sha256 calculate error");
+            return -1;
+        }
+        return rc;
+    }
+    off_t lseek(off_t offset, int whence) override {
+        return m_file->lseek(offset, whence);
+    }
+    std::string sha256_checksum() {
+        // read trailing data
+        char buf[64*1024];
+        auto rc = m_file->read(buf, 64*1024);
+        if (rc == 64*1024) {
+            LOG_WARN("too much trailing data");
+        }
+        if (rc > 0 && SHA256_Update(&ctx, buf, rc) < 0) {
+            LOG_ERROR("sha256 calculate error");
+            return "";
+        }
+        // calc sha256 result
+        unsigned char sha[32];
+        SHA256_Final(sha, &ctx);
+        char res[SHA256_DIGEST_LENGTH * 2];
+        for (int i = 0; i < SHA256_DIGEST_LENGTH; i++)
+            sprintf(res + (i * 2), "%02x", sha[i]);
+        return "sha256:" + std::string(res, SHA256_DIGEST_LENGTH * 2);
+    }
+    int fstat(struct stat *buf) override {
+        return m_file->fstat(buf);
+    }
+};

--- a/src/tools/fastoci-apply.cpp
+++ b/src/tools/fastoci-apply.cpp
@@ -1,0 +1,140 @@
+/*
+   Copyright The Overlaybd Authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+#include <cstddef>
+#include <photon/common/alog.h>
+#include <photon/fs/localfs.h>
+#include <photon/fs/virtual-file.h>
+#include <photon/photon.h>
+#include "../overlaybd/lsmt/file.h"
+#include "../overlaybd/zfile/zfile.h"
+#include "../overlaybd/tar/libtar.h"
+#include "../overlaybd/extfs/extfs.h"
+#include "../overlaybd/gzindex/gzfile.h"
+#include "../overlaybd/gzip/gz.h"
+#include <errno.h>
+#include <fcntl.h>
+#include <inttypes.h>
+#include <memory>
+#include <string>
+#include <stdio.h>
+#include <stdlib.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <unistd.h>
+#include "../image_service.h"
+#include "../image_file.h"
+#include "CLI11.hpp"
+#include <openssl/sha.h>
+#include "comm_func.h"
+
+using namespace std;
+using namespace photon::fs;
+
+int dump_tar_headers(IFile *src_file, const string &out) {
+
+    auto dst_file = open_file(out.c_str(), O_TRUNC | O_CREAT | O_RDWR, 0644);
+    if (dst_file == nullptr) {
+        LOG_ERRNO_RETURN(0, -1, "create dst file failed.");
+    }
+    DEFER({ delete dst_file; });
+    auto tar = new UnTar(src_file, nullptr, 0, 4096, nullptr, false);
+    auto obj_count = tar->dump_tar_headers(dst_file);
+    if (obj_count < 0) {
+        return -1;
+    }
+    LOG_INFO("objects count: `", obj_count);
+    return 0;
+}
+
+int main(int argc, char **argv) {
+    std::string image_config_path, input_path, gz_index_path, config_path;
+    bool raw = false, mkfs = false, verbose = false;
+    bool export_tar_headers = false, import_tar_headers = false;
+
+    CLI::App app{"this is fastoci-apply, apply OCIv1 tar layer to overlaybd-fastoci format"};
+    app.add_flag("--mkfs", mkfs, "mkfs before apply")->default_val(false);
+    app.add_flag("--verbose", verbose, "output debug info")->default_val(false);
+    app.add_option("--service_config_path", config_path, "overlaybd image service config path")
+        ->type_name("FILEPATH")
+        ->check(CLI::ExistingFile)
+        ->default_val("/etc/overlaybd/overlaybd.json");
+    app.add_option("--gz_index_path", gz_index_path,
+                   "build gzip index if layer is gzip, only used with fastoci")
+        ->type_name("FILEPATH")
+        ->default_val("gzip.meta");
+    app.add_flag("--import", import_tar_headers, "generate fastoci file from <input_path>")
+        ->default_val(false);
+    app.add_flag("--export", export_tar_headers, "export tar meta from <input_path>")
+        ->default_val(false);
+    app.add_option("input_path", input_path, "input OCIv1 tar(gz) layer path")
+        ->type_name("FILEPATH")
+        ->check(CLI::ExistingFile)
+        ->required();
+    app.add_option("image_config_path", image_config_path, "overlaybd image config path")
+        ->type_name("FILEPATH");
+    //->check(CLI::ExistingFile)->required();
+    CLI11_PARSE(app, argc, argv);
+    set_log_output_level(verbose ? 0 : 1);
+    photon::init(photon::INIT_EVENT_DEFAULT, photon::INIT_IO_DEFAULT);
+    DEFER({ photon::fini(); });
+
+    photon::fs::IFile *src_file = nullptr;
+    auto tarf = open_file(input_path.c_str(), O_RDONLY, 0666);
+    DEFER(delete tarf);
+
+    if (is_gzfile(tarf)) {
+        auto res = create_gz_index(tarf, gz_index_path.c_str(), 1024 * 1024);
+        LOG_INFO("create_gz_index as ` `", gz_index_path, VALUE(res));
+        tarf->lseek(0, 0);
+        src_file = open_gzfile_adaptor(input_path.c_str());
+    } else {
+        src_file = tarf;
+    }
+    if (export_tar_headers) {
+        return dump_tar_headers(src_file, image_config_path);
+    }
+    auto lfs = new_localfs_adaptor();
+    if (lfs->access(image_config_path.c_str(), 0) != 0) {
+        LOG_ERROR_RETURN(0, -1, "can't found overlaybd config: `", image_config_path);
+    }
+
+    ImageService *imgservice = nullptr;
+    photon::fs::IFile *imgfile = nullptr;
+    create_overlaybd(config_path, image_config_path, imgservice, imgfile);
+
+    DEFER({
+        delete imgfile;
+        delete imgservice;
+    });
+
+    // for now, buffer_file can't be used with fastoci
+    auto target = create_ext4fs(imgfile, mkfs, false, "/");
+    DEFER({ delete target; });
+
+    photon::fs::IFile *base_file = raw ? nullptr : ((ImageFile *)imgfile)->get_base();
+    bool gen_fastoci = true;
+    int option = (import_tar_headers ? TAR_IGNORE_CRC : 0);
+    auto tar =
+        new UnTar(src_file, target, option, 4096, base_file, gen_fastoci, import_tar_headers);
+
+    if (tar->extract_all() < 0) {
+        fprintf(stderr, "failed to extract\n");
+        exit(-1);
+    }
+    fprintf(stdout, "fastoci-apply done\n");
+    return 0;
+}


### PR DESCRIPTION
  - export tar meta from a tar(.tgz) file.
  - import tar meta to apply a overlaybd layer.

  Tar Meta is a little different from original Tar Header, which
contains the logical offset of data written to the overlaybd.

**What this PR does / why we need it**:

A stand-alone tool of fastoci that can export/import tar(.gz) meta separately, making fastoci more flexible.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Please check the following list**:
- [x]  Does the affected code have corresponding tests, e.g. unit test, E2E test?
- [ ]  Does this change require a documentation update?
- [x]  Does this introduce breaking changes that would require an announcement or bumping the major version?
- [ ]  Do all new files have an appropriate license header?

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues directly to https://github.com/containerd/overlaybd/blob/main/MAINTAINERS. -->
