### PR TITLE
fix bug in retry open zfile

### DIFF
--- a/src/overlaybd/zfile/zfile.cpp
+++ b/src/overlaybd/zfile/zfile.cpp
@@ -338,13 +338,18 @@ public:
 
             int get_current_block() {
                 m_reader->m_buf_offset = m_reader->get_buf_offset(m_reader->m_idx);
-                if ((size_t)(m_reader->m_buf_offset) > sizeof(m_buf)) {
+                if ((size_t)(m_reader->m_buf_offset) >= sizeof(m_buf)) {
                     m_reader->m_eno = ERANGE;
                     LOG_ERRNO_RETURN(0, -1, "get inner buffer offset failed.");
                 }
 
                 auto blk_idx = m_reader->m_idx;
                 compressed_size = m_reader->compressed_size();
+                if ((size_t)(m_reader->m_buf_offset) + compressed_size > sizeof(m_buf)) {
+                    m_reader->m_eno = ERANGE;
+                    LOG_ERRNO_RETURN(0, -1, "inner buffer offset (`) + compressed size (`) overflow.",
+                                    m_reader->m_buf_offset, compressed_size);
+                }
 
                 if (blk_idx == m_reader->m_begin_idx) {
                     cp_begin = m_reader->get_inblock_offset(m_reader->m_offset);


### PR DESCRIPTION
**What this PR does / why we need it**:
fix bug in retry open zfile, move new_tar_file_adaptor out of new_switch_file.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #256 

**Please check the following list**:
- [ ]  Does the affected code have corresponding tests, e.g. unit test, E2E test?
- [ ]  Does this change require a documentation update?
- [ ]  Does this introduce breaking changes that would require an announcement or bumping the major version?
- [ ]  Do all new files have an appropriate license header?

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues directly to https://github.com/containerd/overlaybd/blob/main/MAINTAINERS. -->
