### PR TITLE
Fix bugs in zfile evict and build jump table.

### DIFF
--- a/src/overlaybd/tar/tar_file.cpp
+++ b/src/overlaybd/tar/tar_file.cpp
@@ -158,6 +158,12 @@ public:
     virtual ssize_t pwritev(const struct iovec *iov, int iovcnt, off_t offset) override {
         return m_file->pwritev(iov, iovcnt, offset + base_offset);
     }
+    virtual int fallocate(int mode, off_t offset, off_t len) override {
+        return m_file->fallocate(mode, offset + base_offset, len);
+    }
+    virtual int fadvise(off_t offset, off_t len, int advice) override {
+        return m_file->fadvise(offset + base_offset, len, advice);
+    }
 
     virtual int close() override {
         if (is_new_tar()) {


### PR DESCRIPTION
**What this PR does / why we need it**:
1. Return value of building zfile jump table is not checked, dirty data may load into jump table;
2. Retry building jump table doesn't work;
3. Zfile trim has defect due to tar_file not implementing fallocate;

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

**Please check the following list**:
- [ ]  Does the affected code have corresponding tests, e.g. unit test, E2E test?
- [ ]  Does this change require a documentation update?
- [ ]  Does this introduce breaking changes that would require an announcement or bumping the major version?
- [ ]  Do all new files have an appropriate license header?

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues directly to https://github.com/containerd/overlaybd/blob/main/MAINTAINERS. -->
