### PR TITLE
[bugfix] duplicate bearer

### DIFF
--- a/src/overlaybd/registryfs/registryfs_v2.cpp
+++ b/src/overlaybd/registryfs/registryfs_v2.cpp
@@ -138,8 +138,7 @@ public:
         op.req.reset(Verb::GET, *actual_url);
         // set token if needed
         if (actual_info->mode == UrlMode::Self && !actual_info->info.empty()) {
-            op.req.headers.insert(kAuthHeaderKey, "Bearer ");
-            op.req.headers.value_append(actual_info->info);
+            op.req.headers.insert(kAuthHeaderKey, actual_info->info);
         }
         op.req.headers.range(offset, offset + count - 1);
         op.set_enable_proxy(m_client->has_proxy());


### PR DESCRIPTION
**What this PR does / why we need it**:
Fix bug within registryfs_v2. `actual_info->info` already contains the prefix "bearer", and this will result in `"bearer bearer ..."`.
When overlaybd's configuration field `registryFsVersion` has a value of `v2` and works with the self-storage registry, this bug occurs and results in a 401 error for on-demand requests.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Please check the following list**:
- [ ]  Does the affected code have corresponding tests, e.g. unit test, E2E test?
- [ ]  Does this change require a documentation update?
- [ ]  Does this introduce breaking changes that would require an announcement or bumping the major version?
- [ ]  Do all new files have an appropriate license header?

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues directly to https://github.com/containerd/overlaybd/blob/main/MAINTAINERS. -->
