### PR TITLE
save digest of zfile's header/trailer and index

### DIFF
--- a/src/overlaybd/zfile/format_spec.md
+++ b/src/overlaybd/zfile/format_spec.md
@@ -21,14 +21,15 @@ The format of header is described as below. All fields are little-endian.
 |  :---:  |    :----:      |    :----:    | :---        |
 | magic0  |       0        |      8       | "ZFile\0\1" (and an implicit '\0') |
 | magic1  |       8        |      16      | 74 75 6A 69, 2E 79 79 66, 40 41 6C 69, 62 61 62 61 |
-|  size   |      24        |   uint32_t   | size of the header struct (108), excluding the tail padding |
-| reserved|      28        |      4       | reserved space, should be 0 |
+|  size   |      24        |   uint32_t   | size of the header structure, excluding the tail padding |
+| digest  |      28        |   uint32_t   | checksum for the range 28-511 bytes in header |
 | flags   |      32        |   uint64_t   | bits for flags* (see later for details) |
 | index_offset | 40        |   uint64_t   | index offset |
-| index_size   | 48        |   uint64_t   | size of the index section, possibly compressed|
+| index_size   | 48        |   uint64_t   | size of the index section, possibly compressed base on flags |
 | original_file_size | 56  |   uint64_t   | size of the orignal file before compression |
-| reserved|      64        |      8       | reserved space, should be 0 |
-| block_size   | 72        |   uint32_t   | size of each compression block |
+| index_crc |    64        |   uint32_t   | checksum value of index |
+| reserved|      68        |      4       | reserved space, should be 0 |
+| block_size|    72        |   uint32_t   | size of each compression block |
 | algo    |      76        |   uint8_t    | compression algorithm |
 | level   |      77        |   uint8_t    | compression level |
 | use_dict|      78        |     bool     | whether use dictionary |
@@ -45,7 +46,9 @@ The format of header is described as below. All fields are little-endian.
 |     type    |       1       | this is a data file (1) or index file (0) |
 |    sealed   |       2       | this file is sealed (1) or not (0) |
 | info_valid  |       3       | information validity of the fields *after* flags (they were initially invalid (0) after creation; and readers must resort to trailer when they meet such headers) |
-|   reserved  |      4~63     | reserved for future use; must be 0s |
+|    digest   |       4       | the digest of this header/trailer has been recorded in the digest field |
+| index_comperssion | 5       | whether the index has been compressed(1) or not(0) |
+|   reserved  |       6~63    | reserved for future use; must be 0s |
 
 
 ## index

--- a/src/overlaybd/zfile/test/test.cpp
+++ b/src/overlaybd/zfile/test/test.cpp
@@ -227,6 +227,38 @@ TEST_F(ZFileTest, validation_check) {
     EXPECT_NE(zfile_validation_check(fdst.get()), 0);
 }
 
+TEST_F(ZFileTest, ht_check) {
+    // log_output_level = 1;
+    auto fn_src = "verify.data";
+    auto fn_zfile = "verify.zfile";
+    auto src = lfs->open(fn_src, O_CREAT | O_TRUNC | O_RDWR /*| O_DIRECT */, 0644);
+    unique_ptr<IFile> fsrc(src);
+    if (!fsrc) {
+        LOG_ERROR("err: `(`)", errno, strerror(errno));
+    }
+    randwrite(fsrc.get(), 1024);
+    struct stat _st;
+    if (fsrc->fstat(&_st) != 0) {
+        LOG_ERROR("err: `(`)", errno, strerror(errno));
+        return;
+    }
+    auto dst = lfs->open(fn_zfile, O_CREAT | O_TRUNC | O_RDWR /*| O_DIRECT */, 0644);
+    unique_ptr<IFile> fdst(dst);
+    if (!fdst) {
+        LOG_ERROR("err: `(`)", errno, strerror(errno));
+    }
+    CompressOptions opt;
+    opt.algo = CompressOptions::LZ4;
+    opt.verify = 1;
+    CompressArgs args(opt);
+    int ret = zfile_compress(fsrc.get(), fdst.get(), &args);
+    EXPECT_EQ(ret, 0);
+    auto x=2324;
+    dst->pwrite(&x, sizeof(x), 400);
+    EXPECT_NE(zfile_validation_check(fdst.get()), 0);
+    EXPECT_EQ(is_zfile(dst), -1);
+}
+
 TEST_F(ZFileTest, dsa) {
     const int buf_size = 1024;
     const int crc_count = 3000;


### PR DESCRIPTION
**What this PR does / why we need it**:

Since there is unexpected behavior if incorrect data gets during the process of zfile loading, we should add a digest of header/trailer and index to make the dirty data can be evicted.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

releated issues: #253 #254  #255 #261 

**Please check the following list**:
- [x]  Does the affected code have corresponding tests, e.g. unit test, E2E test?
- [x]  Does this change require a documentation update?
- [ ]  Does this introduce breaking changes that would require an announcement or bumping the major version?
- [ ]  Do all new files have an appropriate license header?

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues directly to https://github.com/containerd/overlaybd/blob/main/MAINTAINERS. -->
