### PR TITLE
[bugfix] turboOCI commit with uuid

### DIFF
--- a/src/overlaybd/lsmt/file.cpp
+++ b/src/overlaybd/lsmt/file.cpp
@@ -1127,6 +1127,11 @@ public:
         CompactOptions opts(&m_files, mapping.get(), m_index->size(), m_vsize, &args);
         LayerInfo info;
         info.virtual_size = m_vsize;
+        info.uuid.clear();
+        if (UUID::String::is_valid((args.uuid).c_str())) {
+            LOG_INFO("set UUID: `", args.uuid.data);
+            info.uuid.parse(args.uuid);
+        }
         if (UUID::String::is_valid((args.parent_uuid).c_str())) {
             LOG_INFO("set parent UUID: `", args.parent_uuid.data);
             info.parent_uuid.parse(args.parent_uuid);

--- a/src/overlaybd/lsmt/test/lsmt-filetest.h
+++ b/src/overlaybd/lsmt/test/lsmt-filetest.h
@@ -408,6 +408,7 @@ public:
         data_name.clear();
         idx_name.clear();
         layer_name.clear();
+        parent_uuid = "";
     }
 };
 
@@ -571,6 +572,6 @@ class WarpFileTest : public FileTest3 {
 public:
     void randwrite_warpfile(IFile *file, size_t nwrites);
     IFileRW *create_warpfile_rw(int io_engine = 0);
-    IFileRO *create_commit_warpfile(int io_engine = 0);
-    IFileRO *create_commit_warpfile(IFileRW* warpfile);
+    IFileRO *create_commit_warpfile(int io_engine = 0, bool keepUUID = false);
+    IFileRO *create_commit_warpfile(IFileRW* warpfile, bool keepUUID = false);
 };


### PR DESCRIPTION
**What this PR does / why we need it**:
UUID is missed when using overlaybd-commit with the option `--uuid` and `--turboOCI`, instead of a random uuid in the committed file. After this fix, we can reproduce turboOCI files.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Please check the following list**:
- [x]  Does the affected code have corresponding tests, e.g. unit test, E2E test?
- [ ]  Does this change require a documentation update?
- [ ]  Does this introduce breaking changes that would require an announcement or bumping the major version?
- [ ]  Do all new files have an appropriate license header?

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues directly to https://github.com/containerd/overlaybd/blob/main/MAINTAINERS. -->
