### PR TITLE
build overlaybd using static compiled libcurl 7.42.1

### DIFF
--- a/CMake/FindCURL.cmake
+++ b/CMake/FindCURL.cmake
@@ -1,0 +1,54 @@
+include(FetchContent)
+
+if(${BUILD_CURL_FROM_SOURCE})
+    message("Add and build standalone libcurl")
+    include(FetchContent)
+    FetchContent_Declare(
+        curl_bundle
+        GIT_REPOSITORY https://github.com/curl/curl.git
+        GIT_TAG curl-7_42_1
+        GIT_PROGRESS 1)
+
+    FetchContent_GetProperties(curl_bundle)
+
+    # In libcurl, CMakeLists build static lib is broken add build command via
+    # make
+    if(NOT TARGET libcurl_static_build)
+        if (NOT curl_bundle_POPULATED)
+            FetchContent_Populate(curl_bundle)
+        endif()
+        add_custom_command(
+            OUTPUT ${curl_bundle_BINARY_DIR}/lib/libcurl.a
+            WORKING_DIRECTORY ${curl_bundle_SOURCE_DIR}
+            COMMAND
+                autoreconf -i && sh configure --with-openssl --without-libssh2
+                --enable-static --enable-shared=no --enable-optimize
+                --enable-symbol-hiding --disable-manual --without-libidn
+                --prefix=${curl_bundle_BINARY_DIR} && make -j && make install)
+        add_custom_target(libcurl_static_build
+                          DEPENDS ${curl_bundle_BINARY_DIR}/lib/libcurl.a)
+    endif()
+
+    set(CURL_FOUND yes)
+    set(CURL_LIBRARY ${curl_bundle_BINARY_DIR}/lib/libcurl.a)
+    set(CURL_THIRDPARTY_DEPS crypto ssl z)
+    set(CURL_LIBRARIES ${CURL_LIBRARY} ${CURL_THIRDPARTY_DEPS})
+    set(CURL_INCLUDE_DIR ${curl_bundle_BINARY_DIR}/include)
+    set(CURL_INCLUDE_DIRS ${CURL_INCLUDE_DIR})
+    set(CURL_VERSION_STRING 7.42.1)
+
+    # Use libcurl static lib instead of cmake defined shared lib
+    if(NOT TARGET CURL::libcurl)
+        add_library(CURL::libcurl UNKNOWN IMPORTED)
+    endif()
+    add_dependencies(CURL::libcurl libcurl_static_build)
+    message("${CURL_LIBRARY}")
+    set_target_properties(
+        CURL::libcurl
+        PROPERTIES IMPORTED_LINK_INTERFACE_LANGUAGES "C"
+                   IMPORTED_LOCATION "${CURL_LIBRARY}"
+                   INTERFACE_INCLUDE_DIRECTORIES "${CURL_INCLUDE_DIRS}"
+                   INTERFACE_LINK_LIBRARIES "${CURL_THIRDPARTY_DEPS}")
+else()
+    include(${CMAKE_ROOT}/Modules/FindCURL.cmake)
+endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,7 +39,7 @@ endif()
 set(CMAKE_CXX_STANDARD 14)
 set(CMAKE_CXX_STANDARD_REQUIRED on)
 set(ENABLE_MIMIC_VDSO off)
-
+option(BUILD_CURL_FROM_SOURCE "Compile static libcurl" on)
 find_package(photon REQUIRED)
 find_package(tcmu REQUIRED)
 


### PR DESCRIPTION
**What this PR does / why we need it**:

OverlayBD works with libcurl, using some  features that only support in certain version of libcurl.

This patch make it able to build libcurl with source and link the static library, as default.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #266 by build libcurl 7.42.1 and link static lib.

**Please check the following list**:
- [ ]  Does the affected code have corresponding tests, e.g. unit test, E2E test?
- [ ]  Does this change require a documentation update?
- [ ]  Does this introduce breaking changes that would require an announcement or bumping the major version?
- [ ]  Do all new files have an appropriate license header?

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues directly to https://github.com/containerd/overlaybd/blob/main/MAINTAINERS. -->
