### PR TITLE
fix workflow release dependencies

### DIFF
--- a/.github/workflows/release/build.sh
+++ b/.github/workflows/release/build.sh
@@ -50,11 +50,11 @@ elif [[ ${OS} =~ "centos" ]]; then
     fi
 
     yum install -y epel-release libaio-devel libcurl-devel openssl-devel libnl3-devel e2fsprogs-devel
-    yum install -y rpm-build make git wget sudo
-    yum install --skip-broken -y libzstd-static libzstd-devel
+    yum install -y rpm-build make git wget sudo autoconf automake libtool
+    yum install --skip-broken -y libzstd-static gcc gcc-c++ binutils libzstd-devel
 elif [[ ${OS} =~ "mariner" ]]; then
     yum install -y libaio-devel libcurl-devel openssl-devel libnl3-devel e2fsprogs-devel glibc-devel libzstd-devel binutils ca-certificates-microsoft build-essential
-    yum install -y rpm-build make git wget sudo tar gcc gcc-c++
+    yum install -y rpm-build make git wget sudo tar gcc gcc-c++ autoconf automake libtool
 
     DISTRO=${OS/:/.}
     PACKAGE_RELEASE="-DPACKAGE_RELEASE=1.${DISTRO}"

--- a/CMake/FindCURL.cmake
+++ b/CMake/FindCURL.cmake
@@ -21,9 +21,18 @@ if(${BUILD_CURL_FROM_SOURCE})
             OUTPUT ${curl_bundle_BINARY_DIR}/lib/libcurl.a
             WORKING_DIRECTORY ${curl_bundle_SOURCE_DIR}
             COMMAND
+                export CC=${CMAKE_C_COMPILER} &&
+                export CXX=${CMAKE_CXX_COMPILER} &&
+                export LD=${CMAKE_LINKER} &&
+                export CFLAGS=-fPIC &&
                 autoreconf -i && sh configure --with-openssl --without-libssh2
                 --enable-static --enable-shared=no --enable-optimize
                 --enable-symbol-hiding --disable-manual --without-libidn
+                --disable-ftp --disable-file --disable-ldap --disable-ldaps
+                --disable-rtsp --disable-dict --disable-telnet --disable-tftp
+                --disable-pop3 --disable-imap --disable-smb --disable-smtp
+                --disable-gopher --without-nghttp2 --enable-http
+                --with-pic=PIC
                 --prefix=${curl_bundle_BINARY_DIR} && make -j && make install)
         add_custom_target(libcurl_static_build
                           DEPENDS ${curl_bundle_BINARY_DIR}/lib/libcurl.a)


### PR DESCRIPTION
**What this PR does / why we need it**:

The static libcurl build procedure needs autoconf, automake and libtool in system, add dependency installing step for publish build scrilp.

To unify static libcurl dependencies, disabled features that do not used in overlaybd.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #266 

**Please check the following list**:
- [ ]  Does the affected code have corresponding tests, e.g. unit test, E2E test?
- [ ]  Does this change require a documentation update?
- [ ]  Does this introduce breaking changes that would require an announcement or bumping the major version?
- [ ]  Do all new files have an appropriate license header?

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues directly to https://github.com/containerd/overlaybd/blob/main/MAINTAINERS. -->
