### PR TITLE
fix segfault in open lower

### DIFF
--- a/src/image_file.cpp
+++ b/src/image_file.cpp
@@ -278,6 +278,10 @@ int ImageFile::open_lower_layer(IFile *&file, ImageConfigNS::LayerConfig &layer,
         }
     }
 
+    if (file == nullptr) {
+        return -1;
+    }
+
     if (m_prefetcher != nullptr) {
         file = m_prefetcher->new_prefetch_file(file, index);
     }


### PR DESCRIPTION
**What this PR does / why we need it**:

fix segfault when failed to open remote layer for image with acceleration layer

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Please check the following list**:
- [ ]  Does the affected code have corresponding tests, e.g. unit test, E2E test?
- [ ]  Does this change require a documentation update?
- [ ]  Does this introduce breaking changes that would require an announcement or bumping the major version?
- [ ]  Do all new files have an appropriate license header?

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues directly to https://github.com/containerd/overlaybd/blob/main/MAINTAINERS. -->
