### PR TITLE
build static openssl when building static libcurl

### DIFF
--- a/CMake/FindCURL.cmake
+++ b/CMake/FindCURL.cmake
@@ -17,6 +17,7 @@ if(${BUILD_CURL_FROM_SOURCE})
         if (NOT curl_bundle_POPULATED)
             FetchContent_Populate(curl_bundle)
         endif()
+        find_package(OpenSSL)
         add_custom_command(
             OUTPUT ${curl_bundle_BINARY_DIR}/lib/libcurl.a
             WORKING_DIRECTORY ${curl_bundle_SOURCE_DIR}
@@ -25,22 +26,24 @@ if(${BUILD_CURL_FROM_SOURCE})
                 export CXX=${CMAKE_CXX_COMPILER} &&
                 export LD=${CMAKE_LINKER} &&
                 export CFLAGS=-fPIC &&
-                autoreconf -i && sh configure --with-openssl --without-libssh2
-                --enable-static --enable-shared=no --enable-optimize
-                --enable-symbol-hiding --disable-manual --without-libidn
+                autoreconf -i && sh configure --with-ssl="${OPENSSL_ROOT_DIR}"
+                --without-libssh2 --enable-static --enable-shared=no --enable-optimize
+                --disable-manual --without-libidn
                 --disable-ftp --disable-file --disable-ldap --disable-ldaps
                 --disable-rtsp --disable-dict --disable-telnet --disable-tftp
                 --disable-pop3 --disable-imap --disable-smb --disable-smtp
                 --disable-gopher --without-nghttp2 --enable-http
                 --with-pic=PIC
-                --prefix=${curl_bundle_BINARY_DIR} && make -j && make install)
+                --prefix="${curl_bundle_BINARY_DIR}" && make -j 8 && make install)
         add_custom_target(libcurl_static_build
                           DEPENDS ${curl_bundle_BINARY_DIR}/lib/libcurl.a)
+        add_dependencies(libcurl_static_build openssl102_static_build)
+        make_directory(${curl_bundle_BINARY_DIR}/include)
     endif()
 
     set(CURL_FOUND yes)
     set(CURL_LIBRARY ${curl_bundle_BINARY_DIR}/lib/libcurl.a)
-    set(CURL_THIRDPARTY_DEPS crypto ssl z)
+    set(CURL_THIRDPARTY_DEPS OpenSSL::SSL OpenSSL::Crypto z)
     set(CURL_LIBRARIES ${CURL_LIBRARY} ${CURL_THIRDPARTY_DEPS})
     set(CURL_INCLUDE_DIR ${curl_bundle_BINARY_DIR}/include)
     set(CURL_INCLUDE_DIRS ${CURL_INCLUDE_DIR})

--- a/CMake/FindOpenSSL.cmake
+++ b/CMake/FindOpenSSL.cmake
@@ -1,0 +1,67 @@
+include(FetchContent)
+
+if(${BUILD_CURL_FROM_SOURCE})
+    message("Add and build standalone libopenssl")
+    include(FetchContent)
+
+    # make openssl into bundle
+    FetchContent_Declare(
+        openssl102
+        GIT_REPOSITORY https://github.com/openssl/openssl.git
+        GIT_TAG OpenSSL_1_0_2-stable
+        GIT_PROGRESS 1)
+
+    FetchContent_GetProperties(openssl102)
+
+    if(NOT TARGET openssl102_static_build)
+        if(NOT openssl102_POPULATED)
+            FetchContent_Populate(openssl102)
+        endif()
+        add_custom_command(
+            OUTPUT ${openssl102_BINARY_DIR}/lib/libssl.a
+            WORKING_DIRECTORY ${openssl102_SOURCE_DIR}
+            COMMAND
+                sh config -fPIC no-unit-test no-shared
+                --openssldir="${openssl102_BINARY_DIR}"
+                --prefix="${openssl102_BINARY_DIR}" && make depend -j && make
+                -j 8 && make install)
+        add_custom_target(openssl102_static_build
+                          DEPENDS ${openssl102_BINARY_DIR}/lib/libssl.a)
+        make_directory(${openssl102_BINARY_DIR}/include)
+    endif()
+
+    set(OPENSSL_FOUND yes)
+    set(OPENSSL_ROOT_DIR ${openssl102_BINARY_DIR})
+    set(OPENSSL_INCLUDE_DIR ${OPENSSL_ROOT_DIR}/include)
+    set(OPENSSL_INCLUDE_DIRS ${OPENSSL_INCLUDE_DIR})
+    set(OPENSSL_SSL_LIBRARY ${OPENSSL_ROOT_DIR}/lib/libssl.a)
+    set(OPENSSL_SSL_LIBRARIES ${OPENSSL_SSL_LIBRARY})
+    set(OPENSSL_CRYPTO_LIBRARY ${OPENSSL_ROOT_DIR}/lib/libcrypto.a)
+    set(OPENSSL_CRYPTO_LIBRARIES ${OPENSSL_CRYPTO_LIBRARY})
+    set(OPENSSL_LINK_DIR ${OPENSSL_ROOT_DIR}/lib)
+    set(OPENSSL_LINK_DIRS ${OPENSSL_LINK_DIR})
+
+    if(NOT TARGET OpenSSL::SSL)
+        add_library(OpenSSL::SSL STATIC IMPORTED)
+        add_dependencies(OpenSSL::SSL openssl102_static_build)
+        set_target_properties(
+            OpenSSL::SSL
+            PROPERTIES IMPORTED_LINK_INTERFACE_LANGUAGES "C"
+                       IMPORTED_LOCATION "${OPENSSL_SSL_LIBRARY}"
+                       INTERFACE_INCLUDE_DIRECTORIES "${OPENSSL_INCLUDE_DIRS}"
+                       INTERFACE_LINK_LIBRARIES "${OPENSSL_SSL_LIBRARY}")
+    endif()
+
+    if(NOT TARGET OpenSSL::Crypto)
+        add_library(OpenSSL::Crypto STATIC IMPORTED)
+        add_dependencies(OpenSSL::Crypto openssl102_static_build)
+        set_target_properties(
+            OpenSSL::Crypto
+            PROPERTIES IMPORTED_LINK_INTERFACE_LANGUAGES "C"
+                       IMPORTED_LOCATION "${OPENSSL_CRYPTO_LIBRARY}"
+                       INTERFACE_INCLUDE_DIRECTORIES "${OPENSSL_INCLUDE_DIRS}"
+                       INTERFACE_LINK_LIBRARIES "${OPENSSL_CRYPTO_LIBRARY}")
+    endif()
+else()
+    include(${CMAKE_ROOT}/Modules/FindOpenSSL.cmake)
+endif()

--- a/CMake/Findphoton.cmake
+++ b/CMake/Findphoton.cmake
@@ -14,4 +14,11 @@ if(BUILD_TESTING)
 else()
   FetchContent_MakeAvailable(photon)
 endif()
+
+if (BUILD_CURL_FROM_SOURCE)
+  find_package(OpenSSL REQUIRED)
+  find_package(CURL REQUIRED)
+  add_dependencies(photon_obj CURL::libcurl OpenSSL::SSL OpenSSL::Crypto)
+endif()
+
 set(PHOTON_INCLUDE_DIR ${photon_SOURCE_DIR}/include/)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,7 +39,7 @@ endif()
 set(CMAKE_CXX_STANDARD 14)
 set(CMAKE_CXX_STANDARD_REQUIRED on)
 set(ENABLE_MIMIC_VDSO off)
-option(BUILD_CURL_FROM_SOURCE "Compile static libcurl" on)
+option(BUILD_CURL_FROM_SOURCE "Compile static libcurl" off)
 find_package(photon REQUIRED)
 find_package(tcmu REQUIRED)
 

--- a/README.md
+++ b/README.md
@@ -77,6 +77,14 @@ make -j
 sudo make install
 ```
 
+Considering some libcurl and libopenssl has API changes, if want to build a make-sured compatible version libcurl and openssl, and link to executable as static library.
+
+Noticed that building libcurl and openssl depends on `autoconf` `automake` and `libtool`.
+
+```bash
+cmake -D BUILD_CURL_FROM_SOURCE=1 ..
+```
+
 If you want to use the [original libext2fs](https://github.com/tytso/e2fsprogs) instead of our [customized libext2fs](https://github.com/data-accelerator/e2fsprogs).
 
 ```bash


### PR DESCRIPTION
**What this PR does / why we need it**:
Changes default compile option as do not build with static libcurl/openssl, to keep binaries acts like before.

In last fix, static libcurl still using shared linked libssl & libcrypto. Since current distributed OS default openssl version are
usually using version higher than 1.1.0，that old libcurl version can not recognize it, will prevent libcurl enabling https feature.

Whole static openssl building makes those dependencies using static build openssl 1.0.2k.

Related CMake options document has been added in README.md

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Please check the following list**:
- [ ]  Does the affected code have corresponding tests, e.g. unit test, E2E test?
- [x]  Does this change require a documentation update?
- [ ]  Does this introduce breaking changes that would require an announcement or bumping the major version?
- [ ]  Do all new files have an appropriate license header?

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues directly to https://github.com/containerd/overlaybd/blob/main/MAINTAINERS. -->
