### PR TITLE
update regitsryfs v2 and use v2 as default

### DIFF
--- a/CMake/Findphoton.cmake
+++ b/CMake/Findphoton.cmake
@@ -4,7 +4,7 @@ set(FETCHCONTENT_QUIET false)
 FetchContent_Declare(
   photon
   GIT_REPOSITORY https://github.com/alibaba/PhotonLibOS.git
-  GIT_TAG v0.6.10
+  GIT_TAG v0.6.11
 )
 
 if(BUILD_TESTING)

--- a/README.md
+++ b/README.md
@@ -199,7 +199,7 @@ Default configure file `overlaybd.json` is installed to `/etc/overlaybd/`.
 | enableAudit         | Enable audit or not.                                                                                  |
 | enableThread        | Enable overlaybd device run in seprate thread or not. Note `cacheType` should be `ocf`. `false` is default. |
 | auditPath           | The path for audit file, `/var/log/overlaybd-audit.log` is the default value.                         |
-| registryFsVersion   | registry client version, 'v1' libcurl based, 'v2' is photon http based. 'v1' is the default value.    |
+| registryFsVersion   | registry client version, 'v1' libcurl based, 'v2' is photon http based. 'v2' is the default value.    |
 | prefetchConfig.concurrency    | Prefetch concurrency for reloading trace, `16` is default                                   |
 
 > NOTE: `download` is the config for background downloading. After an overlaybd device is lauched, a background task will be running to fetch the whole blobs into local directories. After downloading, I/O requests are directed to local files. Unlike other options, download config is reloaded when a device launching.

--- a/src/config.h
+++ b/src/config.h
@@ -140,7 +140,7 @@ struct GlobalConfig : public ConfigUtils::Config {
     APPCFG_PARA(p2pConfig, P2PConfig);
     APPCFG_PARA(exporterConfig, ExporterConfig);
     APPCFG_PARA(auditPath, std::string, "/var/log/overlaybd-audit.log");
-    APPCFG_PARA(registryFsVersion, std::string, "v1");
+    APPCFG_PARA(registryFsVersion, std::string, "v2");
     APPCFG_PARA(cacheConfig, CacheConfig);
     APPCFG_PARA(gzipCacheConfig, GzipCacheConfig);
     APPCFG_PARA(logConfig, LogConfig);

--- a/src/overlaybd/registryfs/registryfs.h
+++ b/src/overlaybd/registryfs/registryfs.h
@@ -35,5 +35,10 @@ photon::fs::IFileSystem *new_registryfs_v1(PasswordCB callback,
 photon::fs::IFileSystem *new_registryfs_v2(PasswordCB callback,
                                            const char *caFile = nullptr,
                                            uint64_t timeout = -1);
-}
 
+photon::fs::IFile* new_registry_uploader(photon::fs::IFile *lfile,
+                                         std::string &upload_url,
+                                         std::string &username, std::string &password,
+                                         uint64_t timeout,
+                                         ssize_t upload_bs = -1);
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

- use registryfs version v2 as default, which is based on PhotonLibOS http client module. registryfs v2 performs much faster then v1(libcurl based).
- add registry uploader in registryfs v2 which can used in image conversion.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Please check the following list**:
- [ ]  Does the affected code have corresponding tests, e.g. unit test, E2E test?
- [x]  Does this change require a documentation update?
- [ ]  Does this introduce breaking changes that would require an announcement or bumping the major version?
- [ ]  Do all new files have an appropriate license header?

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues directly to https://github.com/containerd/overlaybd/blob/main/MAINTAINERS. -->
