### PR TITLE
fix mkfs by marking inode 1

### DIFF
--- a/src/overlaybd/extfs/mkfs.cpp
+++ b/src/overlaybd/extfs/mkfs.cpp
@@ -115,6 +115,7 @@ int do_mkfs(io_manager manager, size_t size) {
         return ret;
     }
     // reserve inodes
+    ext2fs_inode_alloc_stats2(fs, EXT2_BAD_INO, +1, 0);
     for (ext2_ino_t i = EXT2_ROOT_INO + 1; i < EXT2_FIRST_INODE(fs->super); i++)
         ext2fs_inode_alloc_stats2(fs, i, +1, 0);
     ext2fs_mark_ib_dirty(fs);


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixed the problem of disk space being incorrectly reported as full due to the incorrect status of inode1 in lower version Linux kernel.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes https://github.com/containerd/accelerated-container-image/discussions/238

**Please check the following list**:
- [ ]  Does the affected code have corresponding tests, e.g. unit test, E2E test?
- [ ]  Does this change require a documentation update?
- [ ]  Does this introduce breaking changes that would require an announcement or bumping the major version?
- [ ]  Do all new files have an appropriate license header?

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues directly to https://github.com/containerd/overlaybd/blob/main/MAINTAINERS. -->
