### PR TITLE
support create raw image, extfs test use make_extfs

### DIFF
--- a/src/overlaybd/extfs/test/test.cpp
+++ b/src/overlaybd/extfs/test/test.cpp
@@ -269,18 +269,21 @@ int remove_all(photon::fs::IFileSystem *fs, const std::string &path) {
 
 photon::fs::IFileSystem *init_extfs() {
     std::string rootfs = "/tmp/rootfs.img";
-    // mkfs
-    std::string cmd = "mkfs.ext4 -F -b 4096 " + rootfs + " 100M";
-    auto ret = system(cmd.c_str());
-    if (ret != 0) {
-        LOG_ERRNO_RETURN(0, nullptr, "failed mkfs");
-    }
-
     // new extfs
-    auto image_file = photon::fs::open_localfile_adaptor(rootfs.c_str(), O_RDWR, 0644, 0);
+    auto image_file = photon::fs::open_localfile_adaptor(rootfs.c_str(), O_RDWR | O_CREAT | O_TRUNC, 0644, 0);
     if (!image_file) {
         LOG_ERRNO_RETURN(0, nullptr, "failed to open `", rootfs);
     }
+    if (image_file->ftruncate(100 << 20) < 0) {
+        delete image_file;
+        LOG_ERRNO_RETURN(0, nullptr, "failed to truncate image to 100M");
+    }
+
+    if (make_extfs(image_file) < 0) {
+        delete image_file;
+        LOG_ERRNO_RETURN(0, nullptr, "failed to mkfs");
+    }
+
     photon::fs::IFileSystem *extfs = new_extfs(image_file);
     if (!extfs) {
         delete image_file;


### PR DESCRIPTION
**What this PR does / why we need it**:
1. overlaybd-create support create raw image (test use);
2. extfs test use make_extfs instead of mkfs.ext4;

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Please check the following list**:
- [x]  Does the affected code have corresponding tests, e.g. unit test, E2E test?
- [ ]  Does this change require a documentation update?
- [ ]  Does this introduce breaking changes that would require an announcement or bumping the major version?
- [ ]  Do all new files have an appropriate license header?

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues directly to https://github.com/containerd/overlaybd/blob/main/MAINTAINERS. -->
