### PR TITLE
update vsize when lsmt stack files if needed

### DIFF
--- a/src/overlaybd/lsmt/file.h
+++ b/src/overlaybd/lsmt/file.h
@@ -74,10 +74,12 @@ public:
         return this->ioctl(Index_Group_Commit, buffer_size);
     }
 
+    // update vsize for current rw layer
+    virtual int update_vsize(size_t vsize) = 0;
+
     // commit the written content as a new file, without garbages
     // return 0 for success, -1 otherwise
     virtual int commit(const CommitArgs &args) const = 0;
-    // virtual int commit(IFile* as) const = 0;
 
     // close and seal current file, optionally returning a new
     // read-only file, with ownership of underlaying file transferred


### PR DESCRIPTION
**What this PR does / why we need it**:

update vsize and rewrite header for lsmt rw layer with zero vsize, which means inherit the vsize of lower, when lstm stack files.
After this change, the result of lsmt committed files remain consistent with the previous version.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Please check the following list**:
- [ ]  Does the affected code have corresponding tests, e.g. unit test, E2E test?
- [ ]  Does this change require a documentation update?
- [ ]  Does this introduce breaking changes that would require an announcement or bumping the major version?
- [ ]  Do all new files have an appropriate license header?

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues directly to https://github.com/containerd/overlaybd/blob/main/MAINTAINERS. -->
