### PR TITLE
fix sign-compares and lz4 include

### DIFF
--- a/src/bk_download.cpp
+++ b/src/bk_download.cpp
@@ -195,7 +195,7 @@ bool BkDownload::download_blob() {
     DEFER(free(buff));
 
     LOG_INFO("download blob start. (`)", url);
-    while (offset < file_size) {
+    while (offset < (ssize_t)file_size) {
         if (running != 1) {
             LOG_INFO("image file exit when background downloading");
             return false;
@@ -203,7 +203,7 @@ bool BkDownload::download_blob() {
         if (!force_download) {
             // check aleady downloaded.
             auto hole_pos = dst->lseek(offset, SEEK_HOLE);
-            if (hole_pos >= offset + bs) {
+            if (hole_pos >= offset + (ssize_t)bs) {
                 // alread downloaded
                 offset += bs;
                 continue;

--- a/src/image_file.cpp
+++ b/src/image_file.cpp
@@ -341,7 +341,7 @@ LSMT::IFileRO *ImageFile::open_lowers(std::vector<ImageConfigNS::LayerConfig> &l
         photon::thread_join(ths[i]);
     }
 
-    for (int i = 0; i < files.size(); i++) {
+    for (size_t i = 0; i < files.size(); i++) {
         if (files[i] == NULL) {
             LOG_ERROR("layer index ` open failed, exit.", i);
             if (m_exception == "")
@@ -367,7 +367,7 @@ ERROR_EXIT:
     if (m_exception == "") {
         m_exception = "failed to create overlaybd device";
     }
-    for (int i = 0; i < lowers.size(); i++) {
+    for (size_t i = 0; i < lowers.size(); i++) {
         if (files[i] != NULL)
             delete files[i];
     }

--- a/src/image_service.cpp
+++ b/src/image_service.cpp
@@ -74,7 +74,7 @@ int parse_blob_url(const std::string &url, struct ImageRef &ref) {
                 prev = idx + 1;
             }
             ref.seg = std::vector<std::string>{words[0]};
-            for (int i = 2; i + 1 < words.size(); i++) {
+            for (size_t i = 2; i + 1 < words.size(); i++) {
                 ref.seg.push_back(words[i]);
             }
         }

--- a/src/overlaybd/cache/ocf_cache/CMakeLists.txt
+++ b/src/overlaybd/cache/ocf_cache/CMakeLists.txt
@@ -12,7 +12,7 @@ file(GLOB_RECURSE src_ocf ocf/src/*.c)
 add_library(ocf_lib STATIC ${src_ocf})
 target_include_directories(ocf_lib PUBLIC include/ ease_bindings/env/)
 target_link_libraries(ocf_lib ocf_env_lib z)
-target_compile_options(ocf_lib PUBLIC -Wno-sign-compare)
+target_compile_options(ocf_lib PRIVATE -Wno-sign-compare)
 
 # ocf_cache_lib
 file(GLOB src_ocf_cache ocf_cache.cpp ocf_namespace.cpp ease_bindings/*.cpp)

--- a/src/overlaybd/extfs/test/test.cpp
+++ b/src/overlaybd/extfs/test/test.cpp
@@ -57,7 +57,7 @@ int write_file(photon::fs::IFile *file) {
     while (aa.size() < FILE_SIZE)
         aa.append(bb);
     auto ret = file->pwrite(aa.data(), aa.size(), 0);
-    if (ret != aa.size()) {
+    if (ret != (ssize_t)aa.size()) {
         LOG_ERRNO_RETURN(0, -1, "failed write file ", VALUE(aa.size()), VALUE(ret))
     }
     LOG_DEBUG("write ` byte", ret);

--- a/src/overlaybd/gzindex/test/test.cpp
+++ b/src/overlaybd/gzindex/test/test.cpp
@@ -139,7 +139,7 @@ private:
         if (gzdata == nullptr) {
             LOG_ERRNO_RETURN(0, -1, "failed to create `", fn_gzdata);
         }
-        if (gzdata->pwrite(gzbuf, gzlen, 0) != gzlen) {
+        if (gzdata->pwrite(gzbuf, gzlen, 0) != (ssize_t)gzlen) {
             LOG_ERRNO_RETURN(0, -1, "failed to pwrite `", fn_gzdata);
         }
         return 0;
@@ -373,7 +373,7 @@ private:
         if (gzdata == nullptr) {
             LOG_ERRNO_RETURN(0, -1, "failed to create `", fn_gzdata);
         }
-        if (gzdata->pwrite(gzbuf, gzlen, 0) != gzlen) {
+        if (gzdata->pwrite(gzbuf, gzlen, 0) != (ssize_t)gzlen) {
             LOG_ERRNO_RETURN(0, -1, "failed to pwrite `", fn_gzdata);
         }
         return 0;
@@ -446,7 +446,7 @@ TEST_F(GzCacheTest, cache_store) {
     fread(cbuf1, 1, vsize, fp1);
     fread(cbuf2, 1, vsize, fp2);
     // refill_size is 1MB
-    for (int i = 0; i < vsize; i++) {
+    for (size_t i = 0; i < vsize; i++) {
         if (check_in_interval(i, 0, 1 << 20) ||
             check_in_interval(i, vsize - (1 << 20), vsize) ||
             check_in_interval(i, 5 << 20, 6 << 20)) {

--- a/src/overlaybd/zfile/compressor.h
+++ b/src/overlaybd/zfile/compressor.h
@@ -20,7 +20,6 @@
 #include <cstdlib>
 #include <cstdint>
 #include <memory>
-#include "lz4/lz4.h"
 
 namespace photon {
     namespace fs {

--- a/src/prefetch.cpp
+++ b/src/prefetch.cpp
@@ -273,7 +273,7 @@ private:
         // Reload content
         uint32_t checksum = 0;
         TraceFormat fmt = {};
-        for (int i = 0; i < hdr.data_size / sizeof(TraceFormat); ++i) {
+        for (size_t i = 0; i < hdr.data_size / sizeof(TraceFormat); ++i) {
             n_read = m_trace_file->read(&fmt, sizeof(TraceFormat));
             if (n_read != sizeof(TraceFormat)) {
                 LOG_ERRNO_RETURN(0, -1, "Prefetch: reload content failed");

--- a/src/test/simple_credsrv_test.cpp
+++ b/src/test/simple_credsrv_test.cpp
@@ -64,7 +64,7 @@ public:
         resp.keep_alive(true);
         photon::thread_sleep(1);
         auto ret_w = resp.write((void*)msg.c_str(), msg.size());
-        if (ret_w != msg.size()) {
+        if (ret_w != (ssize_t)msg.size()) {
             LOG_ERRNO_RETURN(0, -1,
                     "send body failed, target: `, `", req.target(), VALUE(ret_w));
         } else {


### PR DESCRIPTION
**What this PR does / why we need it**:

- fix sign-compare errors affected by ocf's CMake configuration
- remove lz4 include in compressor.h

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Please check the following list**:
- [ ]  Does the affected code have corresponding tests, e.g. unit test, E2E test?
- [ ]  Does this change require a documentation update?
- [ ]  Does this introduce breaking changes that would require an announcement or bumping the major version?
- [ ]  Do all new files have an appropriate license header?

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues directly to https://github.com/containerd/overlaybd/blob/main/MAINTAINERS. -->
