### PR TITLE
minor fixes & tools improvements

### DIFF
--- a/CMake/Findphoton.cmake
+++ b/CMake/Findphoton.cmake
@@ -5,7 +5,7 @@ set(PHOTON_ENABLE_EXTFS ON)
 FetchContent_Declare(
   photon
   GIT_REPOSITORY https://github.com/alibaba/PhotonLibOS.git
-  GIT_TAG v0.6.14
+  GIT_TAG v0.6.15
 )
 
 if(BUILD_TESTING)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.15)
+cmake_minimum_required(VERSION 3.14)
 
 project(
   overlaybd

--- a/README.md
+++ b/README.md
@@ -201,6 +201,8 @@ Default configure file `overlaybd.json` is installed to `/etc/overlaybd/`.
 | auditPath           | The path for audit file, `/var/log/overlaybd-audit.log` is the default value.                         |
 | registryFsVersion   | registry client version, 'v1' libcurl based, 'v2' is photon http based. 'v2' is the default value.    |
 | prefetchConfig.concurrency    | Prefetch concurrency for reloading trace, `16` is default                                   |
+| certConfig.certFile | The path for SSL/TLS client certificate file                                                          |
+| certConfig.keyFile  | The path for SSL/TLS client key file                                                                  |
 
 > NOTE: `download` is the config for background downloading. After an overlaybd device is lauched, a background task will be running to fetch the whole blobs into local directories. After downloading, I/O requests are directed to local files. Unlike other options, download config is reloaded when a device launching.
 

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ It is better to run `overlaybd-tcmu` as a service so that it can be restarted af
 
 To build overlaybd from source code, the following dependencies are required:
 
-* CMake >= 3.15
+* CMake >= 3.14
 
 * gcc/g++ >= 7
 

--- a/src/config.h
+++ b/src/config.h
@@ -123,6 +123,13 @@ struct PrefetchConfig : public ConfigUtils::Config {
     APPCFG_PARA(concurrency, int, 16);
 };
 
+struct CertConfig : public ConfigUtils::Config {
+    APPCFG_CLASS
+
+    APPCFG_PARA(certFile, std::string, "");
+    APPCFG_PARA(keyFile, std::string, "");
+};
+
 struct GlobalConfig : public ConfigUtils::Config {
     APPCFG_CLASS
 
@@ -145,6 +152,7 @@ struct GlobalConfig : public ConfigUtils::Config {
     APPCFG_PARA(gzipCacheConfig, GzipCacheConfig);
     APPCFG_PARA(logConfig, LogConfig);
     APPCFG_PARA(prefetchConfig, PrefetchConfig);
+    APPCFG_PARA(certConfig, CertConfig);
 };
 
 struct AuthConfig : public ConfigUtils::Config {

--- a/src/image_service.cpp
+++ b/src/image_service.cpp
@@ -348,7 +348,8 @@ int ImageService::init() {
             registryfs_creator = new_registryfs_v2;
 
         global_fs.underlay_registryfs = registryfs_creator(
-            {this, &ImageService::reload_auth}, cafile, 30UL * 1000000);
+            {this, &ImageService::reload_auth}, cafile, 30UL * 1000000,
+            global_conf.certConfig().certFile().c_str(), global_conf.certConfig().keyFile().c_str());
         if (global_fs.underlay_registryfs == nullptr) {
             LOG_ERROR_RETURN(0, -1, "create registryfs failed.");
         }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -32,6 +32,7 @@
 #include <fcntl.h>
 #include <scsi/scsi.h>
 #include <sys/resource.h>
+#include <sys/prctl.h>
 
 class TCMUDevLoop;
 
@@ -401,6 +402,7 @@ void sigint_handler(int signal = SIGINT) {
 
 int main(int argc, char **argv) {
     mallopt(M_TRIM_THRESHOLD, 128 * 1024);
+    prctl(PR_SET_THP_DISABLE, 1);
 
     photon::init(photon::INIT_EVENT_DEFAULT, photon::INIT_IO_DEFAULT);
     photon::block_all_signal();

--- a/src/overlaybd/base64.h
+++ b/src/overlaybd/base64.h
@@ -1,3 +1,5 @@
+#pragma once
+
 #ifndef _BASE64_H_
 #define _BASE64_H_
 
@@ -13,7 +15,7 @@ static inline bool is_base64(BYTE c) {
     return (isalnum(c) || (c == '+') || (c == '/'));
 }
 
-std::string base64_encode(BYTE const *buf, unsigned int bufLen) {
+static inline std::string base64_encode(BYTE const *buf, unsigned int bufLen) {
     std::string ret;
     int i = 0;
     int j = 0;
@@ -53,7 +55,7 @@ std::string base64_encode(BYTE const *buf, unsigned int bufLen) {
     return ret;
 }
 
-std::string base64_decode(std::string const &encoded_string) {
+static inline std::string base64_decode(std::string const &encoded_string) {
     int in_len = encoded_string.size();
     int i = 0;
     int j = 0;

--- a/src/overlaybd/registryfs/registryfs.h
+++ b/src/overlaybd/registryfs/registryfs.h
@@ -30,15 +30,21 @@ using PasswordCB = Delegate<std::pair<std::string, std::string>, const char *>;
 extern "C" {
 photon::fs::IFileSystem *new_registryfs_v1(PasswordCB callback,
                                            const char *caFile = nullptr,
-                                           uint64_t timeout = -1);
+                                           uint64_t timeout = -1,
+                                           const char *cert_file = nullptr,
+                                           const char *key_file = nullptr);
 
 photon::fs::IFileSystem *new_registryfs_v2(PasswordCB callback,
                                            const char *caFile = nullptr,
-                                           uint64_t timeout = -1);
+                                           uint64_t timeout = -1,
+                                           const char *cert_file = nullptr,
+                                           const char *key_file = nullptr);
 
 photon::fs::IFile* new_registry_uploader(photon::fs::IFile *lfile,
                                          std::string &upload_url,
                                          std::string &username, std::string &password,
                                          uint64_t timeout,
-                                         ssize_t upload_bs = -1);
+                                         ssize_t upload_bs = -1,
+                                         const char *cert_file = nullptr,
+                                         const char *key_file = nullptr);
 }

--- a/src/tools/CMakeLists.txt
+++ b/src/tools/CMakeLists.txt
@@ -1,6 +1,6 @@
 add_executable(overlaybd-commit overlaybd-commit.cpp)
 target_include_directories(overlaybd-commit PUBLIC ${PHOTON_INCLUDE_DIR})
-target_link_libraries(overlaybd-commit photon_static overlaybd_lib)
+target_link_libraries(overlaybd-commit photon_static overlaybd_image_lib)
 
 add_executable(overlaybd-create overlaybd-create.cpp)
 target_include_directories(overlaybd-create PUBLIC ${PHOTON_INCLUDE_DIR})


### PR DESCRIPTION
**What this PR does / why we need it**:
- [bugfix] libcurl->set_user_passwd(...) may cause basic and bearer auth coexist when the registry's authentication domain name is the same as the registry's domain name (e.g. hub.docker.com/auth/...)
- disable huge page
- cmake 3.15 -> 3.14
- [feat] supports SSL/TLS client certs
- [feat] overlaybd-apply: streaming download and apply
- [feat] overlaybd-commit: streaming zfile compress and upload. This is unavailable with option `-t` because it only supports write-in-sequence, but we have to overwrite the tar header.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Please check the following list**:
- [ ]  Does the affected code have corresponding tests, e.g. unit test, E2E test?
- [x]  Does this change require a documentation update?
- [ ]  Does this introduce breaking changes that would require an announcement or bumping the major version?
- [ ]  Do all new files have an appropriate license header?

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues directly to https://github.com/containerd/overlaybd/blob/main/MAINTAINERS. -->
