### PR TITLE
untar: ignore '/' in tarball

### DIFF
--- a/src/overlaybd/tar/libtar.h
+++ b/src/overlaybd/tar/libtar.h
@@ -210,7 +210,7 @@ private:
     std::set<std::string> unpackedPaths;
     std::list<std::pair<std::string, int>> dirs; // <path, utime>
 
-    int extract_file();
+    int extract_file(const char *filename);
     int extract_regfile(const char *filename);
     int extract_regfile_meta_only(const char *filename);
     int extract_hardlink(const char *filename);


### PR DESCRIPTION
**What this PR does / why we need it**:
It happens that '/' (root dir) exists in some image tarball layer. It will cause userspace convertor failed.
Now, '/' is ignored.
Add a test case for clean_name().

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Please check the following list**:
- [x]  Does the affected code have corresponding tests, e.g. unit test, E2E test?
- [ ]  Does this change require a documentation update?
- [ ]  Does this introduce breaking changes that would require an announcement or bumping the major version?
- [ ]  Do all new files have an appropriate license header?

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues directly to https://github.com/containerd/overlaybd/blob/main/MAINTAINERS. -->
