### PR TITLE
add some method for lsmt, rename crc32c for zfile

### DIFF
--- a/src/overlaybd/lsmt/index.h
+++ b/src/overlaybd/lsmt/index.h
@@ -126,6 +126,8 @@ public:
 
     // number of 512B blocks allocated
     virtual uint64_t block_count() const = 0;
+
+    virtual uint64_t vsize() const = 0;
 };
 
 // the level 0 memory index, which supports write
@@ -169,7 +171,7 @@ inline IMemoryIndex0 *create_memory_index0() {
 // the mapped offset must be within [moffset_begin, moffset_end)
 extern "C" IMemoryIndex *create_memory_index(const SegmentMapping *pmappings, std::size_t n,
                                              uint64_t moffset_begin, uint64_t moffset_end,
-                                             bool ownership = true);
+                                             bool ownership = true, uint64_t vsize = 0);
 
 // merge multiple indexes into a single one index
 // the `tag` field of each element in the result is subscript of `pindexes`:


### PR DESCRIPTION
**What this PR does / why we need it**:
- add some method for lsmt
- rename crc32c for zfile, to reduce the potential for confusion caused by the name.
- 
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Please check the following list**:
- [ ]  Does the affected code have corresponding tests, e.g. unit test, E2E test?
- [ ]  Does this change require a documentation update?
- [ ]  Does this introduce breaking changes that would require an announcement or bumping the major version?
- [ ]  Do all new files have an appropriate license header?

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues directly to https://github.com/containerd/overlaybd/blob/main/MAINTAINERS. -->
