### PR TITLE
support stdin as source for ZFile compression

### DIFF
--- a/src/overlaybd/zfile/test/test.cpp
+++ b/src/overlaybd/zfile/test/test.cpp
@@ -170,6 +170,7 @@ TEST_F(ZFileTest, verify_compression) {
                 opt.block_size = 1<<bs;
                 CompressArgs args(opt);
                 zfile_compress(fsrc.get(), nullptr, &args);
+                fsrc->lseek(0, SEEK_SET);
                 int ret = zfile_compress(fsrc.get(), fdst.get(), &args);
                 auto fzfile = zfile_open_ro(fdst.get(), opt.verify);
                 EXPECT_EQ(ret, 0);


### PR DESCRIPTION
**What this PR does / why we need it**:
Currently, overlaybd-zfile cli only supports local files as a source.
This PR will support STDIN as a source for overlaybd-zfile cli. (eg. cat $file | ./overlaybd-file $out)
Moreover, decompression can't use stdin or pipe as a source since the ZFile index is saved at the end of the file

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Please check the following list**:
- [ ]  Does the affected code have corresponding tests, e.g. unit test, E2E test?
- [ ]  Does this change require a documentation update?
- [ ]  Does this introduce breaking changes that would require an announcement or bumping the major version?
- [ ]  Do all new files have an appropriate license header?

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues directly to https://github.com/containerd/overlaybd/blob/main/MAINTAINERS. -->
