### PR TITLE
[bugfix] ignore aufs entry

### DIFF
--- a/src/overlaybd/tar/libtar.cpp
+++ b/src/overlaybd/tar/libtar.cpp
@@ -133,6 +133,10 @@ int UnTar::extract_all() {
             LOG_WARN("file '/' ignored: resolved to root");
             continue;
         }
+        if (strncmp(name, ".wh..wh.", 8) == 0) {
+            LOG_WARN("file ` ignored: aufs", name);
+            continue;
+        }
         std::string filename(name);
         if (extract_file(filename.c_str()) != 0) {
             LOG_ERRNO_RETURN(0, -1, "extract failed, filename `", filename);


### PR DESCRIPTION
**What this PR does / why we need it**:

ignore aufs entry  in source image during userspace converting

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Please check the following list**:
- [ ]  Does the affected code have corresponding tests, e.g. unit test, E2E test?
- [ ]  Does this change require a documentation update?
- [ ]  Does this introduce breaking changes that would require an announcement or bumping the major version?
- [ ]  Do all new files have an appropriate license header?

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues directly to https://github.com/containerd/overlaybd/blob/main/MAINTAINERS. -->
