### PR TITLE
untar: mv store dirs into extract_file

### DIFF
--- a/src/overlaybd/tar/libtar.cpp
+++ b/src/overlaybd/tar/libtar.cpp
@@ -137,9 +137,6 @@ int UnTar::extract_all() {
         if (extract_file(filename.c_str()) != 0) {
             LOG_ERRNO_RETURN(0, -1, "extract failed, filename `", filename);
         }
-        if (TH_ISDIR(header)) {
-            dirs.emplace_back(std::make_pair(filename, header.get_mtime()));
-        }
         count++;
     }
 
@@ -230,7 +227,11 @@ int UnTar::extract_file(const char *filename) {
     if (i != 0) {
         return i;
     }
-
+    // Directory mtimes must be handled at the end to avoid further
+    // file creation in them to modify the directory mtime
+    if (TH_ISDIR(header)) {
+        dirs.emplace_back(std::make_pair(filename, header.get_mtime()));
+    }
     unpackedPaths.insert(filename);
     return 0;
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
Move store dirs into extract_file. (Directory mtimes must be handled at the end to avoid further file creation in them to modify the directory mtime)
This move will avoid aufs whiteout files (.wh..wh.aufs, .wh..wh.orph/, .wh..wh.plnk/) from creating and setting attributes.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Please check the following list**:
- [x]  Does the affected code have corresponding tests, e.g. unit test, E2E test?
- [ ]  Does this change require a documentation update?
- [ ]  Does this introduce breaking changes that would require an announcement or bumping the major version?
- [ ]  Do all new files have an appropriate license header?

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues directly to https://github.com/containerd/overlaybd/blob/main/MAINTAINERS. -->
