### PR TITLE
Fix build on Arch Linux

### DIFF
--- a/src/bk_download.h
+++ b/src/bk_download.h
@@ -16,6 +16,7 @@
 #pragma once
 #include <list>
 #include <string>
+#include <cstdint>
 #include <photon/fs/filesystem.h>
 
 class ImageFile;


### PR DESCRIPTION
**What this PR does / why we need it**: Fixes a compilation error I get when building on Arch Linux. The numeric types (e.g. uint64_t) are defined in `<cstdint>` and the header file needs to be included.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:


**Please check the following list**:
- [ ]  Does the affected code have corresponding tests, e.g. unit test, E2E test?
- [ ]  Does this change require a documentation update?
- [ ]  Does this introduce breaking changes that would require an announcement or bumping the major version?
- [ ]  Do all new files have an appropriate license header?

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues directly to https://github.com/containerd/overlaybd/blob/main/MAINTAINERS. -->
