### PR TITLE
[bugfix] switch file

### DIFF
--- a/src/switch_file.cpp
+++ b/src/switch_file.cpp
@@ -94,6 +94,7 @@ public:
             LOG_ERROR("failed to open commit file as zfile, path: `", m_filepath);
             return;
         }
+        file = zfile;
         LOG_INFO("switch to localfile '`' success.", m_filepath);
         m_local_file = file;
     }


### PR DESCRIPTION
**What this PR does / why we need it**:
This may cause the read requests from overlaybd device wrong after the switch_file is switched (i.e. after the background download is done).

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Please check the following list**:
- [ ]  Does the affected code have corresponding tests, e.g. unit test, E2E test?
- [ ]  Does this change require a documentation update?
- [ ]  Does this introduce breaking changes that would require an announcement or bumping the major version?
- [ ]  Do all new files have an appropriate license header?

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues directly to https://github.com/containerd/overlaybd/blob/main/MAINTAINERS. -->
