### PR TITLE
Fix EROFS support of TurboOCI-apply

### DIFF
--- a/src/overlaybd/tar/tarerofs.h
+++ b/src/overlaybd/tar/tarerofs.h
@@ -21,8 +21,8 @@
 class TarErofs {
 public:
     TarErofs(photon::fs::IFile *file, photon::fs::IFile *target, uint64_t fs_blocksize = 4096,
-          photon::fs::IFile *bf = nullptr, bool meta_only = true)
-        : file(file), fout(target), fs_base_file(bf), meta_only(meta_only) {}
+          photon::fs::IFile *bf = nullptr, bool meta_only = true, bool first_layer = true)
+        : file(file), fout(target), fs_base_file(bf), meta_only(meta_only), first_layer(first_layer) {}
 
     int extract_all();
 
@@ -31,6 +31,7 @@ private:
     photon::fs::IFile *fout = nullptr; // target
     photon::fs::IFile *fs_base_file = nullptr;
     bool meta_only;
+    bool first_layer;
     std::set<std::string> unpackedPaths;
     std::list<std::pair<std::string, int>> dirs; // <path, utime>
 };

--- a/src/tools/turboOCI-apply.cpp
+++ b/src/tools/turboOCI-apply.cpp
@@ -129,8 +129,14 @@ int main(int argc, char **argv) {
     if (fstype == "erofs") {
         photon::fs::IFile* base_file = raw ? nullptr : ((ImageFile *)imgfile)->get_base();
 
+        ImageConfigNS::ImageConfig cfg;
+        if (!cfg.ParseJSON(image_config_path)) {
+            fprintf(stderr, "failed to parse image config\n");
+            exit(-1);
+        }
+
         auto tar =
-           new TarErofs(src_file, imgfile, 4096, base_file, true);
+           new TarErofs(src_file, imgfile, 4096, base_file, true, cfg.lowers().size() == 0);
 
         if (tar->extract_all() < 0) {
             fprintf(stderr, "failed to extract\n");


### PR DESCRIPTION
**What this PR does / why we need it**:

Fix EROFS support of TurboOCI-apply when applying multiple layers:
 - Correct the bottom layer check;
 - Fix up pread() alignment issue.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Please check the following list**:
- [ ]  Does the affected code have corresponding tests, e.g. unit test, E2E test?
- [ ]  Does this change require a documentation update?
- [ ]  Does this introduce breaking changes that would require an announcement or bumping the major version?
- [ ]  Do all new files have an appropriate license header?

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues directly to https://github.com/containerd/overlaybd/blob/main/MAINTAINERS. -->
