### PR TITLE
[feat.] DynamicPrefetcher

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ The whole project is managed by CMake. Binaries and resource files will be insta
 ```bash
 mkdir build
 cd build
-cmake ..
+cmake .. # -DCMAKE_BUILD_TYPE=Debug -DCMAKE_EXPORT_COMPILE_COMMANDS=true -DBUILD_TESTING=true
 make -j
 sudo make install
 ```

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -14,6 +14,7 @@ add_library(overlaybd_image_lib
   bk_download.cpp
   prefetch.cpp
   tools/sha256file.cpp
+  tools/comm_func.cpp
 )
 target_include_directories(overlaybd_image_lib PUBLIC
   ${CURL_INCLUDE_DIRS}

--- a/src/image_file.cpp
+++ b/src/image_file.cpp
@@ -365,7 +365,7 @@ LSMT::IFileRO *ImageFile::open_lowers(std::vector<ImageConfigNS::LayerConfig> &l
     LOG_INFO("LSMT::open_files_ro(files, `) success", lowers.size());
 
     if (m_prefetcher != nullptr) {
-        m_prefetcher->replay();
+        m_prefetcher->replay((IFile*)ret);
     }
 
     return ret;
@@ -463,7 +463,7 @@ int ImageFile::init_image_file() {
             m_prefetcher = new_prefetcher(trace_file, concurrency);
         }
 
-    } else if (!conf.recordTracePath().empty()) {
+    } else if (!conf.recordTracePath().empty() && (::access(conf.recordTracePath().c_str(), F_OK) == 0)) {
         auto mode = Prefetcher::detect_mode(conf.recordTracePath());
         if (mode != Prefetcher::Mode::Record && mode != Prefetcher::Mode::Replay) {
             LOG_ERROR("Prefetch: incorrect mode ` for prefetching", mode);

--- a/src/image_file.h
+++ b/src/image_file.h
@@ -104,6 +104,7 @@ public:
     uint32_t block_size;
     bool read_only = false;
 
+    // a merged view after stack all layers.
     IFile* get_base() {
         return m_file;
     }

--- a/src/overlaybd/lsmt/file.h
+++ b/src/overlaybd/lsmt/file.h
@@ -35,6 +35,8 @@ namespace LSMT {
 
 static const int MAX_STACK_LAYERS = 255;
 
+static const uint32_t ALIGNMENT = 512; // same as trim block size.
+static const uint32_t ALIGNMENT4K = 4096;
 class IFileRO : public photon::fs::VirtualReadOnlyFile {
 public:
     static const int GetType = 12;

--- a/src/prefetch.h
+++ b/src/prefetch.h
@@ -21,6 +21,9 @@ limitations under the License.
 
 using namespace photon::fs;
 /*
+ * Prefetcher provides a capability which  can download remote data before the true I/O trigger.
+ * It contains two modes:
+ ==== static mode: replay the record I/O trace ====
  * 1. Prefetcher supports `record` and `replay` operations on a specific container image.
  *    It will persist R/W metadata of all layers into a trace file during container boot-up,
  *    and then replay this file, in order to retrieve data in advance.
@@ -35,6 +38,20 @@ using namespace photon::fs;
  *      trace file exist but empty                      => Start Recording
  *      lock file deleted or prefetcher destructed      => Stop Recording
  *      trace file exist and not empty                  => Replay
+ *
+ ==== dynamic mode: reload specified the data from a external file list ====
+ *  overlaybd will read the filelist to prefetch from the value of  'recordTracePath' in config.v1.json
+ * {
+ *    ...
+ *    "recordTracePath": "path/to/filelist",
+ *    ...
+ *}
+ * # cat /path/to/filelist
+ * /absolute/path/to/fileA
+ * /absolute/path/to/fileB
+ * ...
+ * /absolute/path/to/directory   ## support but not recommend
+ *
  */
 class Prefetcher : public Object {
 public:
@@ -45,9 +62,9 @@ public:
     };
     enum class TraceOp : char { READ = 'R', WRITE = 'W' };
 
-    virtual void record(TraceOp op, uint32_t layer_index, size_t count, off_t offset) = 0;
+    virtual int record(TraceOp op, uint32_t layer_index, size_t count, off_t offset) = 0;
 
-    virtual void replay() = 0;
+    virtual int replay(const IFile *imagefile = nullptr) = 0;
 
     // Prefetch file inherits ForwardFile, and it is the actual caller of `record` method.
     // The source file is supposed to have cache.
@@ -64,3 +81,4 @@ protected:
 };
 
 Prefetcher *new_prefetcher(const std::string &trace_file_path, int concurrency);
+Prefetcher *new_dynamic_prefetcher(const std::string &prefetch_list, int concurrency);

--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -37,3 +37,15 @@ target_include_directories(simple_credsrv_test PUBLIC
     ${rapidjson_SOURCE_DIR}/include
     $ENV{GTEST}/googletest/include
 )
+
+add_executable(trace_test trace_test.cpp ../tools/comm_func.cpp)
+target_include_directories(trace_test PUBLIC
+    ${PHOTON_INCLUDE_DIR}
+    ${rapidjson_SOURCE_DIR}/include
+)
+target_link_libraries(trace_test gtest gtest_main gflags pthread photon_static overlaybd_lib overlaybd_image_lib)
+
+add_test(
+    NAME trace_test
+    COMMAND ${EXECUTABLE_OUTPUT_PATH}/trace_test
+)

--- a/src/test/trace_test.cpp
+++ b/src/test/trace_test.cpp
@@ -1,0 +1,143 @@
+#include <fcntl.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <photon/photon.h>
+#include <photon/common/alog.h>
+#include <photon/fs/localfs.h>
+#include <photon/fs/extfs/extfs.h>
+#include <photon/fs/fiemap.h>
+#include <unistd.h>
+#include <vector>
+#include <gtest/gtest.h>
+#include <string>
+#include "../overlaybd/gzip/gz.h"
+#include "../overlaybd/tar/libtar.h"
+#include "../prefetch.cpp"
+
+#include "../tools/comm_func.h"
+#include "../tools/sha256file.h"
+#include "photon/common/utility.h"
+
+using namespace std;
+
+const string test_urls[]={"https://github.com/containerd/overlaybd/archive/refs/tags/v1.0.12.tar.gz"};
+const vector<pair<string, string>> fnlist = {
+    {"1M", "sha256:4e29ad18ab9f42d7c233500771a39d7c852b200baf328fd00fbbe3fecea1eb56"},
+    {"overlaybd-1.0.12/README.md", "sha256:4d4ca22ffdcdced61c121b2961fe24dd0a256f1e37bd866cbbbf02f6a0da0f2c"},
+    {"overlaybd-1.0.12/docs/assets/Scaling_up.jpg", "sha256:d941365f9d087e106dbd7ff804eac19ef362347cd7069ffaad8f84cb12317ee7"},
+    {"overlaybd-1.0.12/src/image_file.h", "sha256:cb98584c50c031c3c3c08d1fc03ad05d733d57a31ec32249a8d1e5150f352528"},
+    {"overlaybd-1.0.12/src/version.h", "sha256:5b216e936c66e971292ff720a4843d9a03bca13d5a8b5dd393c7bedca592ca73"},
+    {"overlaybd-1.0.12/src/main.cpp", "sha256:4653edf45471096d549b2a002d2b10dafb5beb939cff3f1dfc936fb4d75c070a"}
+};
+
+class MockFile : public ForwardFile_Ownership{
+public:
+    char trash_data[1<<20];
+    MockFile(IFile *file) : ForwardFile_Ownership(file, true) {}
+    virtual ssize_t pread(void *buf, size_t count, off_t offset) override {
+        if (buf == nullptr) {
+            return m_file->pread(trash_data, count,offset);
+        }
+        return m_file->pread(buf, count, offset);
+    }
+};
+
+int download(const std::string &url, const std::string &out) {
+    // if (::access(out.c_str(), 0) == 0)
+    //     return 0;
+    auto base = std::string(basename(url.c_str()));
+    // download file
+    if (::access(out.c_str(), 0) == 0) return 0;
+    std::string cmd = "curl -sL -o " + out + " " + url;
+    LOG_INFO(VALUE(cmd.c_str()));
+    auto ret = system(cmd.c_str());
+    if (ret != 0) {
+        LOG_ERRNO_RETURN(0, -1, "download failed: `", url.c_str());
+    }
+    return 0;
+}
+TEST(trace, case0) {
+
+    return;
+
+    std::string workdir = "/tmp/trace_test/";
+    mkdir(workdir.c_str(), 0755);
+    auto dst = open_file((workdir+"img").c_str(), O_CREAT|O_RDWR|O_TRUNC, 0644);
+    dst = new MockFile(dst);
+    DEFER(delete dst);
+    dst->ftruncate(32 << 20);
+
+    auto flist = open_file((workdir+"list").c_str(), O_CREAT|O_RDWR|O_TRUNC, 0644);
+    for (auto it : fnlist) {
+        auto fn = it.first + "\n";
+        flist->write(fn.c_str(), fn.size());
+    }
+    flist->write("overlaybd-1.0.12/src/\n", strlen("overlaybd-1.0.12/src/\n"));
+    delete flist;
+
+    std::string fn_test_tgz = workdir + basename(test_urls[0].c_str());
+    ASSERT_EQ(
+        0, download(test_urls[0], fn_test_tgz.c_str()));
+    auto src = open_gzfile_adaptor(fn_test_tgz.c_str());
+    ASSERT_NE(src, nullptr);
+    // src = open_gzfile_adaptor(src);
+    DEFER(delete src);
+    auto fs = create_ext4fs(dst, true, false, "/");
+    ASSERT_NE(fs, nullptr);
+    DEFER(delete fs);
+    auto tar = new UnTar(src, fs, 0, 4096, nullptr, false);
+    ASSERT_EQ(tar->extract_all(), 0);
+    auto file = fs->open("/1M", O_TRUNC|O_CREAT|O_RDWR, 0644);
+
+    ASSERT_NE(file, nullptr);
+    char buf[1<<20];
+    memset(buf, 'A', sizeof(buf));
+    file->pwrite(buf, 1<<20, 0);
+    delete file;
+
+    auto p = new_dynamic_prefetcher((workdir+"list"), 8);
+    p->replay(dst);
+
+    for (auto fn : fnlist) {
+        vector<pair<off_t, uint64_t>> lba;
+        auto file = fs->open(fn.first.c_str(), O_RDONLY);
+        auto fout = open_file((workdir+"check").c_str(), O_CREAT|O_RDWR|O_TRUNC, 0644);
+        ASSERT_NE(file, nullptr);
+        DEFER(delete file);
+        struct stat buf;
+        file->fstat(&buf);
+        uint64_t size = buf.st_size;
+
+        photon::fs::fiemap_t<8192> fie(0, size);
+        ASSERT_EQ(file->fiemap(&fie), 0);
+        LOG_INFO("check ` size: `, extents: `", fn.first, size, fie.fm_mapped_extents);
+        // uint64_t count = ((size+ T_BLOCKSIZE - 1) / T_BLOCKSIZE) * T_BLOCKSIZE;
+        for (uint32_t i = 0; i < fie.fm_mapped_extents; i++) {
+            LOG_INFO("get segment: ` `", fie.fm_extents[i].fe_physical, fie.fm_extents[i].fe_length);
+            lba.push_back(make_pair(fie.fm_extents[i].fe_physical, fie.fm_extents[i].fe_length < size ? fie.fm_extents[i].fe_length : size));
+            size -= lba.back().second;
+        }
+        for (auto it : lba) {
+            char data[4<<20];
+            LOG_INFO("write segment: ` `", it.first, it.second);
+            dst->pread(data, it.second, it.first);
+            fout->write(data, it.second);
+        }
+        fout->lseek(0, SEEK_SET);
+        auto sha256file = new_sha256_file(fout, true);
+        DEFER(delete sha256file);
+        LOG_INFO("verify sha256 of `", fn.first);
+        ASSERT_STREQ(sha256file->sha256_checksum().c_str(), fn.second.c_str());
+    }
+    delete p;
+}
+
+
+int main(int argc, char **arg) {
+    photon::init();
+    DEFER(photon::fini());
+
+    set_log_output_level(ALOG_INFO);
+    ::testing::InitGoogleTest(&argc, arg);
+    return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
DynamePrefetcher allows users to pass a filelist through the label 'containerd.io/snapshot/overlaybd/record-trace-path' to prefetch the files during container startup.

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Please check the following list**:
- [ ]  Does the affected code have corresponding tests, e.g. unit test, E2E test?
- [x]  Does this change require a documentation update?
- [ ]  Does this introduce breaking changes that would require an announcement or bumping the major version?
- [ ]  Do all new files have an appropriate license header?

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues directly to https://github.com/containerd/overlaybd/blob/main/MAINTAINERS. -->
