### PR TITLE
[EROFS] Add support for xattr reservation of the base layer rootdir

### DIFF
--- a/src/overlaybd/tar/erofs/CMakeLists.txt
+++ b/src/overlaybd/tar/erofs/CMakeLists.txt
@@ -3,7 +3,7 @@ include(FetchContent)
 FetchContent_Declare(
     erofs-utils
     GIT_REPOSITORY git://git.kernel.org/pub/scm/linux/kernel/git/xiang/erofs-utils.git
-    GIT_TAG        617d708925b3c5d1dd132853e47d9d9f51443e6f
+    GIT_TAG        ac0997ea32a465a6b0db7b782bb8d4d07952365a
 )
 
 FetchContent_MakeAvailable(erofs-utils)

--- a/src/overlaybd/tar/erofs/liberofs.cpp
+++ b/src/overlaybd/tar/erofs/liberofs.cpp
@@ -17,6 +17,7 @@
 #define round_down_blk(addr) ((addr) & (~(SECTOR_SIZE - 1)))
 #define round_up_blk(addr) (round_down_blk((addr) + SECTOR_SIZE - 1))
 #define min(a, b) (a) < (b) ? (a) : (b)
+#define EROFS_ROOT_XATTR_SZ (16 * 1024)
 
 #define EROFS_UNIMPLEMENTED 1
 
@@ -641,6 +642,10 @@ int LibErofs::extract_tar(photon::fs::IFile *source, bool meta_only, bool first_
     cfg.incremental = !first_layer;
     erofs_cfg = erofs_get_configure();
     erofs_cfg->c_ovlfs_strip = true;
+    if (first_layer)
+        erofs_cfg->c_root_xattr_isize = EROFS_ROOT_XATTR_SZ;
+    else
+        erofs_cfg->c_root_xattr_isize = 0;
     cfg.mp_fp = std::tmpfile();
 
     err = erofs_mkfs(&cfg);


### PR DESCRIPTION
**What this PR does / why we need it**:
Set the minimum inline xattr size for the root directory of the base layer, as there may not be enough room for xattr during the incremental build process.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Please check the following list**:
- [ ]  Does the affected code have corresponding tests, e.g. unit test, E2E test?
- [ ]  Does this change require a documentation update?
- [ ]  Does this introduce breaking changes that would require an announcement or bumping the major version?
- [ ]  Do all new files have an appropriate license header?

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues directly to https://github.com/containerd/overlaybd/blob/main/MAINTAINERS. -->
