### PR TITLE
Switch erofs endpoint to use https

### DIFF
--- a/src/overlaybd/tar/erofs/CMakeLists.txt
+++ b/src/overlaybd/tar/erofs/CMakeLists.txt
@@ -2,7 +2,7 @@ include(FetchContent)
 
 FetchContent_Declare(
     erofs-utils
-    GIT_REPOSITORY git://git.kernel.org/pub/scm/linux/kernel/git/xiang/erofs-utils.git
+    GIT_REPOSITORY https://git.kernel.org/pub/scm/linux/kernel/git/xiang/erofs-utils.git
     GIT_TAG        ac0997ea32a465a6b0db7b782bb8d4d07952365a
 )
 


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR is a tiny change to move the erofs dependency from using the git protocol to https. The main reasoning behind it is to better support builds behind firewalls which have become more and more strict in recent times as security pushes happen. We have encountered such issues where firewalls restrict ports other than 443 and 80 for security but using the git protocol uses 9418.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Please check the following list**:
- [ ]  Does the affected code have corresponding tests, e.g. unit test, E2E test?
- [ ]  Does this change require a documentation update?
- [ ]  Does this introduce breaking changes that would require an announcement or bumping the major version?
- [ ]  Do all new files have an appropriate license header?

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues directly to https://github.com/containerd/overlaybd/blob/main/MAINTAINERS. -->
