### PR TITLE
fix arm build

### DIFF
--- a/.github/workflows/release/build.sh
+++ b/.github/workflows/release/build.sh
@@ -59,9 +59,15 @@ elif [[ ${OS} =~ "centos" ]]; then
         export PATH="/opt/rh/devtoolset-7/root/usr/bin:$PATH"
         PACKAGE_RELEASE="-DPACKAGE_RELEASE=${RELEASE_NO}.el7"
         COMPILER="-DCMAKE_C_COMPILER=/opt/rh/devtoolset-7/root/usr/bin/gcc -DCMAKE_CXX_COMPILER=/opt/rh/devtoolset-7/root/usr/bin/g++"
+        /opt/rh/devtoolset-7/root/usr/bin/gcc --version
+        /opt/rh/devtoolset-7/root/usr/bin/g++ --version
     elif [[ ${OS} == "centos:8" ]]; then
         rm -rf /etc/yum.repos.d/* && curl -o /etc/yum.repos.d/CentOS-Base.repo https://mirrors.aliyun.com/repo/Centos-vault-8.5.2111.repo
-        yum install -y gcc gcc-c++
+
+        yum install -y gcc-toolset-9-gcc gcc-toolset-9-gcc-c++
+        COMPILER="-DCMAKE_C_COMPILER=/opt/rh/gcc-toolset-9/root/usr/bin/gcc -DCMAKE_CXX_COMPILER=/opt/rh/gcc-toolset-9/root/usr/bin/g++"
+        /opt/rh/gcc-toolset-9/root/usr/bin/gcc --version
+        /opt/rh/gcc-toolset-9/root/usr/bin/g++ --version
 
         PACKAGE_RELEASE="-DPACKAGE_RELEASE=${RELEASE_NO}.el8"
     fi

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,6 +6,9 @@ project(
 )
 enable_language(C)
 
+set(CMAKE_CXX_FLAGS_RELEASE "-O2 -DNDEBUG")
+set(CMAKE_CXX_FLAGS_RELWITHDEBINFO "-O2 -DNDEBUG -g")
+
 # Get CPU arch
 execute_process(COMMAND uname -m OUTPUT_VARIABLE ARCH OUTPUT_STRIP_TRAILING_WHITESPACE)
 if (NOT (${ARCH} STREQUAL x86_64) AND NOT (${ARCH} STREQUAL aarch64) AND NOT (${ARCH} STREQUAL arm64))
@@ -23,7 +26,7 @@ set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fpic -Wall -Werror=sign-compare")
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fpic -Wall -Werror=sign-compare -DOVERLAYBD_VER=${OBD_VER}")
 
 if (${ARCH} STREQUAL aarch64)
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fsigned-char")
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -march=armv8-a+crc -fsigned-char -fno-stack-protector -fomit-frame-pointer")
 endif ()
 
 set(CMAKE_CXX_STANDARD_LIBRARIES "-static-libgcc ${CMAKE_CXX_STANDARD_LIBRARIES}")

--- a/src/overlaybd/zfile/CMakeLists.txt
+++ b/src/overlaybd/zfile/CMakeLists.txt
@@ -17,7 +17,7 @@ target_include_directories(crc32_lib PUBLIC
 if (${ARCH} STREQUAL x86_64)
     target_compile_options(crc32_lib PUBLIC -msse4.2 -mcrc32)
 else()
-    target_compile_options(crc32_lib PUBLIC -march=native -mcpu=generic+crc)
+    target_compile_options(crc32_lib PRIVATE -march=native -mcpu=generic+crc)
 endif()
 
 if(ENABLE_DSA OR ENABLE_ISAL)


### PR DESCRIPTION
**What this PR does / why we need it**:
In the release workflow, we are using gcc 8.5.1 on centos8, which can be problematic for compiling the arm64 binary. We should use gcc 9.2.1 instead.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Please check the following list**:
- [ ]  Does the affected code have corresponding tests, e.g. unit test, E2E test?
- [ ]  Does this change require a documentation update?
- [ ]  Does this introduce breaking changes that would require an announcement or bumping the major version?
- [ ]  Do all new files have an appropriate license header?

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues directly to https://github.com/containerd/overlaybd/blob/main/MAINTAINERS. -->
