### PR TITLE
[Fix] access deleted point in prefetch thread.

### DIFF
--- a/src/image_file.cpp
+++ b/src/image_file.cpp
@@ -168,7 +168,7 @@ IFile *ImageFile::__open_ro_remote(const std::string &dir, const std::string &di
         remote_file->ioctl(SET_LOCAL_DIR, dir);
     } else {
         LOG_WARN(
-            "local dir of layer %d (%s) didn't set, skip background anyway",
+            "local dir of layer ` (`) didn't set, skip background anyway",
             layer_index, digest.c_str());
     }
 
@@ -364,10 +364,6 @@ LSMT::IFileRO *ImageFile::open_lowers(std::vector<ImageConfigNS::LayerConfig> &l
     }
     LOG_INFO("LSMT::open_files_ro(files, `) success", lowers.size());
 
-    if (m_prefetcher != nullptr) {
-        m_prefetcher->replay((IFile*)ret);
-    }
-
     return ret;
 
 ERROR_EXIT:
@@ -507,6 +503,9 @@ int ImageFile::init_image_file() {
 SUCCESS_EXIT:
     if (conf.download().enable() && !record_no_download) {
         start_bk_dl_thread();
+    }
+    if (m_prefetcher != nullptr) {
+        m_prefetcher->replay(m_file);
     }
     return 1;
 


### PR DESCRIPTION
**What this PR does / why we need it**:

The DynamicPrefetcher::replay(IFile* imgfile) progress is running in a background thread and it will access an invalid pointer after *imgfile  has been deleted in stack_files() 
https://github.com/containerd/overlaybd/blob/7093da0f29da0d3b1dc786f404fbf87c875c366d/src/overlaybd/lsmt/file.cpp#L1790

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Please check the following list**:
- [ ]  Does the affected code have corresponding tests, e.g. unit test, E2E test?
- [ ]  Does this change require a documentation update?
- [ ]  Does this introduce breaking changes that would require an announcement or bumping the major version?
- [ ]  Do all new files have an appropriate license header?

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues directly to https://github.com/containerd/overlaybd/blob/main/MAINTAINERS. -->
