### PR TITLE
[EROFS]: cleanup and introduce prefetch feature

### DIFF
--- a/src/overlaybd/tar/erofs/liberofs.cpp
+++ b/src/overlaybd/tar/erofs/liberofs.cpp
@@ -6,11 +6,13 @@
 #include "erofs/block_list.h"
 #include "erofs/inode.h"
 #include "erofs/config.h"
+#include "erofs/dir.h"
 #include "../../lsmt/file.h"
 #include "../../lsmt/index.h"
 #include <photon/common/alog.h>
 #include <map>
 #include <set>
+#include <dirent.h>
 
 #define SECTOR_SIZE 512ULL
 #define SECTOR_BITS 9
@@ -702,4 +704,471 @@ LibErofs::LibErofs(photon::fs::IFile *target, uint64_t blksize, bool import_tar_
 
 LibErofs::~LibErofs()
 {
+}
+
+class ErofsFileSystem: public photon::fs::IFileSystem {
+public:
+    struct erofs_sb_info sbi;
+    struct liberofs_file target_file;
+
+    ErofsFileSystem(photon::fs::IFile *imgfile, uint64_t blksize);
+    ~ErofsFileSystem();
+    photon::fs::IFile* open(const char *pathname, int flags);
+    photon::fs::IFile* open(const char *pathname, int flags, mode_t mode);
+    photon::fs::IFile* creat(const char *pathname, mode_t mode);
+    int mkdir(const char *pathname, mode_t mode);
+    int rmdir(const char *pathname);
+    int symlink(const char *oldname, const char *newname);
+    ssize_t readlink(const char *path, char *buf, size_t bufsiz);
+    int link(const char *oldname, const char *newname);
+    int rename(const char *oldname, const char *newname);
+    int unlink(const char *filename);
+    int chmod(const char *pathname, mode_t mode);
+    int chown(const char *pathname, uid_t owner, gid_t group);
+    int lchown(const char *pathname, uid_t owner, gid_t group);
+    int statfs(const char *path, struct statfs *buf);
+    int statvfs(const char *path, struct statvfs *buf);
+    int stat(const char *path, struct stat *buf);
+    int lstat(const char *path, struct stat *buf);
+    int access(const char *pathname, int mode);
+    int truncate(const char *path, off_t length);
+    int utime(const char *path, const struct utimbuf *file_times);
+    int utimes(const char *path, const struct timeval times[2]);
+    int lutimes(const char *path, const struct timeval times[2]);
+    int mknod(const char *path, mode_t mode, dev_t dev);
+    int syncfs();
+    photon::fs::DIR* opendir(const char *name);
+};
+
+class ErofsFile: public photon::fs::VirtualReadOnlyFile {
+public:
+    ErofsFileSystem *fs;
+    struct erofs_inode inode;
+
+    ErofsFile(ErofsFileSystem *fs);
+    photon::fs::IFileSystem *filesystem();
+    int fstat(struct stat *buf);
+    int fiemap(struct photon::fs::fiemap *map);
+};
+
+class ErofsDir: public photon::fs::DIR {
+public:
+    std::vector<::dirent> m_dirs;
+    ::dirent *direntp = nullptr;
+    long loc;
+    ErofsDir(std::vector<::dirent> &dirs);
+    ~ErofsDir();
+    int closedir();
+    dirent *get();
+    int next();
+    void rewinddir();
+    void seekdir(long loc);
+    long telldir();
+};
+
+#define EROFS_UNIMPLEMENTED_FUNC(ret_type, cls, func, ret) \
+ret_type cls::func { \
+    return ret; \
+}
+
+// ErofsFile
+ErofsFile::ErofsFile(ErofsFileSystem *fs): fs(fs)
+{
+    memset(&inode, 0, sizeof(struct erofs_inode));
+}
+photon::fs::IFileSystem *ErofsFile::filesystem() { return fs; }
+
+struct liberofs_nameidata {
+    struct erofs_sb_info *sbi;
+	erofs_nid_t	nid;
+};
+
+static int liberofs_link_path_walk(const char *name,
+                                   struct liberofs_nameidata *nd);
+
+static struct erofs_dirent *liberofs_find_dirent(void *data, const char *name,
+                                                unsigned int len,
+                                                unsigned int nameoff,
+                                                unsigned int maxsize)
+{
+    struct erofs_dirent *de = (struct erofs_dirent *)data;
+    const struct erofs_dirent *end = (struct erofs_dirent *)((char *)data + nameoff);
+
+    while (de < end) {
+        const char *de_name;
+        unsigned int de_namelen;
+
+        nameoff = le16_to_cpu(de->nameoff);
+        de_name = (char *)((char *)data + nameoff);
+        if (de + 1 >= end)
+            de_namelen = strnlen(de_name, maxsize - nameoff);
+        else
+            de_namelen = le16_to_cpu(de[1].nameoff - nameoff);
+
+        if (nameoff + de_namelen > maxsize) {
+            LOG_ERROR("[erofs] bogus dirent");
+            return (struct erofs_dirent *)ERR_PTR(-EINVAL);
+        }
+
+        if (len == de_namelen && !memcmp(de_name, name, de_namelen))
+            return de;
+        ++de;
+    }
+    return NULL;
+}
+
+static int liberofs_namei(struct liberofs_nameidata *nd, const char *name,
+                          unsigned int len)
+{
+	erofs_nid_t nid = nd->nid;
+	int ret;
+	char buf[EROFS_MAX_BLOCK_SIZE];
+	struct erofs_sb_info *sbi = nd->sbi;
+	struct erofs_inode vi = {};
+	erofs_off_t offset;
+
+	vi.sbi = sbi;
+	vi.nid = nid;
+	ret = erofs_read_inode_from_disk(&vi);
+	if (ret)
+		return ret;
+
+	offset = 0;
+	while (offset < vi.i_size) {
+		erofs_off_t maxsize = min_t(erofs_off_t,
+					    vi.i_size - offset, erofs_blksiz(sbi));
+		struct erofs_dirent *de = (struct erofs_dirent *)buf;
+		unsigned int nameoff;
+
+		ret = erofs_pread(&vi, buf, maxsize, offset);
+		if (ret)
+			return ret;
+
+		nameoff = le16_to_cpu(de->nameoff);
+		if (nameoff < sizeof(struct erofs_dirent) ||
+            nameoff >= erofs_blksiz(sbi))
+                LOG_ERRNO_RETURN(-EINVAL, -EINVAL, "[erofs] invalid nameoff");
+
+		de = liberofs_find_dirent(buf, name, len, nameoff, maxsize);
+		if (IS_ERR(de))
+			return PTR_ERR(de);
+
+		if (de) {
+			nd->nid = le64_to_cpu(de->nid);
+			return 0;
+		}
+		offset += maxsize;
+	}
+	return -ENOENT;
+}
+
+
+static int liberofs_step_into_link(struct liberofs_nameidata *nd,
+                                   struct erofs_inode *vi)
+{
+    char buf[PATH_MAX];
+    int err;
+
+    if (vi->i_size > PATH_MAX)
+        return -EINVAL;
+    memset(buf, 0, sizeof(buf));
+    err = erofs_pread(vi, buf, vi->i_size, 0);
+    if (err)
+        return err;
+    return liberofs_link_path_walk(buf, nd);
+}
+
+static int liberofs_link_path_walk(const char *name,
+                                   struct liberofs_nameidata *nd)
+{
+    struct erofs_inode vi;
+    erofs_nid_t nid;
+    const char *p;
+    int ret;
+
+    if (*name == '/')
+        nd->nid = nd->sbi->root_nid;
+
+    while (*name == '/')
+        name ++;
+
+    while (*name != '\0') {
+        p = name;
+        do {
+            ++p;
+        } while (*p != '\0' && *p != '/');
+
+        nid = nd->nid;
+        ret = liberofs_namei(nd, name, p - name);
+        if (ret)
+            return ret;
+        vi.sbi = nd->sbi;
+        vi.nid = nd->nid;
+        ret = erofs_read_inode_from_disk(&vi);
+        if (ret)
+            return ret;
+        if (S_ISLNK(vi.i_mode)) {
+            nd->nid = nid;
+            ret = liberofs_step_into_link(nd, &vi);
+            if (ret)
+                return ret;
+        }
+        for (name = p; *name == '/'; ++name)
+            ;
+    }
+    return 0;
+}
+
+
+static int do_erofs_ilookup(const char *path, struct erofs_inode *vi)
+{
+    int ret;
+    struct liberofs_nameidata nd = {.sbi = vi->sbi};
+
+    nd.nid = vi->sbi->root_nid;
+    ret = liberofs_link_path_walk(path, &nd);
+    if (ret)
+        return ret;
+    vi->nid = nd.nid;
+    return erofs_read_inode_from_disk(vi);
+}
+
+int ErofsFile::fstat(struct stat *buf)
+{
+    buf->st_mode = inode.i_mode;
+    buf->st_nlink = inode.i_nlink;
+    buf->st_size = inode.i_size;
+    buf->st_blocks = roundup(inode.i_size, erofs_blksiz(inode.sbi)) >> 9;
+    buf->st_uid = inode.i_uid;
+    buf->st_gid = inode.i_gid;
+    buf->st_ctime = inode.i_mtime;
+    buf->st_mtime = inode.i_mtime;
+    buf->st_atime = inode.i_mtime;
+    return 0;
+}
+
+int ErofsFile::fiemap(struct photon::fs::fiemap *map)
+{
+    photon::fs::fiemap_extent *ext_buf = &map->fm_extents[0];
+    struct erofs_map_blocks erofs_map;
+    int err;
+
+    map->fm_mapped_extents = 0;
+    erofs_map.index = UINT_MAX;
+    erofs_map.m_la = 0;
+
+    while (erofs_map.m_la < inode.i_size) {
+        err = erofs_map_blocks(&inode, &erofs_map, 0);
+        if (err)
+            LOG_ERROR_RETURN(err, err, "[erofs] Fail to map erofs blocks");
+        ext_buf[map->fm_mapped_extents].fe_physical = erofs_map.m_pa;
+        ext_buf[map->fm_mapped_extents].fe_length = erofs_map.m_plen;
+        map->fm_mapped_extents += 1;
+        erofs_map.m_la += erofs_map.m_llen;
+    }
+    return 0;
+}
+
+// ErofsFileSystem
+EROFS_UNIMPLEMENTED_FUNC(photon::fs::IFile*, ErofsFileSystem, open(const char *pathname, int flags, mode_t mode), NULL)
+EROFS_UNIMPLEMENTED_FUNC(photon::fs::IFile*, ErofsFileSystem, creat(const char *pathname, mode_t mode), NULL)
+EROFS_UNIMPLEMENTED_FUNC(int, ErofsFileSystem, mkdir(const char *pathname, mode_t mode), -EROFS_UNIMPLEMENTED)
+EROFS_UNIMPLEMENTED_FUNC(int, ErofsFileSystem, rmdir(const char *pathname), -EROFS_UNIMPLEMENTED)
+EROFS_UNIMPLEMENTED_FUNC(int, ErofsFileSystem, symlink(const char *oldname, const char *newname), -EROFS_UNIMPLEMENTED)
+EROFS_UNIMPLEMENTED_FUNC(ssize_t, ErofsFileSystem, readlink(const char *path, char *buf, size_t bufsiz), -EROFS_UNIMPLEMENTED)
+EROFS_UNIMPLEMENTED_FUNC(int, ErofsFileSystem, link(const char *oldname, const char *newname), -EROFS_UNIMPLEMENTED)
+EROFS_UNIMPLEMENTED_FUNC(int, ErofsFileSystem, rename(const char *oldname, const char *newname), -EROFS_UNIMPLEMENTED)
+EROFS_UNIMPLEMENTED_FUNC(int, ErofsFileSystem, unlink(const char *filename), -EROFS_UNIMPLEMENTED)
+EROFS_UNIMPLEMENTED_FUNC(int, ErofsFileSystem, chmod(const char *pathname, mode_t mode), -EROFS_UNIMPLEMENTED)
+EROFS_UNIMPLEMENTED_FUNC(int, ErofsFileSystem, chown(const char *pathname, uid_t owner, gid_t group), -EROFS_UNIMPLEMENTED)
+EROFS_UNIMPLEMENTED_FUNC(int, ErofsFileSystem, lchown(const char *pathname, uid_t owner, gid_t group), -EROFS_UNIMPLEMENTED)
+EROFS_UNIMPLEMENTED_FUNC(int, ErofsFileSystem, statfs(const char *path, struct statfs *buf), -EROFS_UNIMPLEMENTED)
+EROFS_UNIMPLEMENTED_FUNC(int, ErofsFileSystem, statvfs(const char *path, struct statvfs *buf), -EROFS_UNIMPLEMENTED)
+EROFS_UNIMPLEMENTED_FUNC(int, ErofsFileSystem, lstat(const char *path, struct stat *buf), -EROFS_UNIMPLEMENTED)
+EROFS_UNIMPLEMENTED_FUNC(int, ErofsFileSystem, access(const char *pathname, int mode), -EROFS_UNIMPLEMENTED)
+EROFS_UNIMPLEMENTED_FUNC(int, ErofsFileSystem, truncate(const char *path, off_t length), -EROFS_UNIMPLEMENTED)
+EROFS_UNIMPLEMENTED_FUNC(int, ErofsFileSystem, utime(const char *path, const struct utimbuf *file_times), -EROFS_UNIMPLEMENTED)
+EROFS_UNIMPLEMENTED_FUNC(int, ErofsFileSystem, utimes(const char *path, const struct timeval times[2]), -EROFS_UNIMPLEMENTED)
+EROFS_UNIMPLEMENTED_FUNC(int, ErofsFileSystem, lutimes(const char *path, const struct timeval times[2]), -EROFS_UNIMPLEMENTED)
+EROFS_UNIMPLEMENTED_FUNC(int, ErofsFileSystem, mknod(const char *path, mode_t mode, dev_t dev), -EROFS_UNIMPLEMENTED)
+EROFS_UNIMPLEMENTED_FUNC(int, ErofsFileSystem, syncfs(), -EROFS_UNIMPLEMENTED)
+
+ErofsFileSystem::ErofsFileSystem(photon::fs::IFile *imgfile, uint64_t blksize)
+{
+    target_file.ops.pread = erofs_target_pread;
+    target_file.ops.pwrite = erofs_target_pwrite;
+    target_file.ops.pread = erofs_target_pread;
+    target_file.ops.pwrite = erofs_target_pwrite;
+    target_file.ops.fsync = erofs_target_fsync;
+    target_file.ops.fallocate = erofs_target_fallocate;
+    target_file.ops.ftruncate = erofs_target_ftruncate;
+    target_file.ops.read = erofs_target_read;
+    target_file.ops.lseek = erofs_target_lseek;
+    target_file.file = imgfile;
+    target_file.cache = new ErofsCache(target_file.file, 128);
+
+    memset(&sbi, 0, sizeof(struct erofs_sb_info));
+    (void)erofs_init_sbi(&sbi, target_file.file, &target_file.ops, ilog2(blksize));
+    if (erofs_read_superblock(&sbi))
+        LOG_ERROR("[erofs] Fail to read_super_block");
+}
+
+ErofsFileSystem::~ErofsFileSystem()
+{
+    delete target_file.cache;
+}
+
+int ErofsFileSystem::stat(const char *path, struct stat *buf)
+{
+    struct erofs_inode vi;
+    int err;
+
+    vi.sbi = &sbi;
+    err = do_erofs_ilookup(path, &vi);
+    if (err)
+        LOG_ERRNO_RETURN(err, err, "[erofs] Fail to lookup inode");
+    buf->st_mode = vi.i_mode;
+    buf->st_nlink = vi.i_nlink;
+    buf->st_size = vi.i_size;
+    buf->st_blocks = roundup(vi.i_size, erofs_blksiz(vi.sbi)) >> 9;
+    buf->st_uid = vi.i_uid;
+    buf->st_gid = vi.i_gid;
+    buf->st_ctime = vi.i_mtime;
+    buf->st_mtime = vi.i_mtime;
+    buf->st_atime = vi.i_mtime;
+    return 0;
+}
+
+photon::fs::IFile* ErofsFileSystem::open(const char *pathname, int flags)
+{
+    ErofsFile *file = new ErofsFile(this);
+    int err;
+
+    file->inode.sbi = &sbi;
+    err = do_erofs_ilookup(pathname, &file->inode);
+    if (err) {
+        delete file;
+        LOG_ERROR_RETURN(-err, nullptr, "[erofs] Fail to lookup inode by path");
+    }
+    return file;
+}
+
+struct liberofs_dir_context {
+    struct erofs_dir_context ctx;
+    std::vector<::dirent> *dirs;
+};
+
+static int liberofs_readdir(struct erofs_dir_context *ctx)
+{
+    struct liberofs_dir_context *libctx = reinterpret_cast<struct liberofs_dir_context *>(ctx);
+    std::vector<::dirent> *dirs  = libctx->dirs;
+    struct dirent tmpdir;
+
+    if (ctx->dot_dotdot)
+        return 0;
+
+    tmpdir.d_ino = (ino_t) ctx->de_nid;
+    tmpdir.d_off = 0;
+    tmpdir.d_reclen = sizeof(struct erofs_dirent);
+    if (ctx->de_namelen > sizeof(tmpdir.d_name))
+        LOG_ERROR_RETURN(-EINVAL, -EINVAL, "[erofs] Invalid name length");
+    memset(tmpdir.d_name, 0, sizeof(tmpdir.d_name));
+    memcpy(tmpdir.d_name, ctx->dname, ctx->de_namelen);
+    dirs->emplace_back(tmpdir);
+    return 0;
+}
+
+static int do_erofs_readdir(struct erofs_sb_info *sbi, const char *path,  std::vector<::dirent> *dirs)
+{
+    struct liberofs_dir_context ctx;
+    struct erofs_inode vi;
+    int err;
+
+    vi.sbi = sbi;
+    err = do_erofs_ilookup(path, &vi);
+    if (err)
+        LOG_ERRNO_RETURN(err, err, "[erofs] Fail to lookup inode");
+    ctx.ctx.dir = &vi;
+    ctx.ctx.cb = liberofs_readdir;
+    ctx.dirs = dirs;
+
+    return erofs_iterate_dir(&ctx.ctx, false);
+}
+
+photon::fs::DIR* ErofsFileSystem::opendir(const char *name)
+{
+    std::vector<::dirent> dirs;
+
+    auto ret = do_erofs_readdir(&sbi, name, &dirs);
+    if (ret) {
+        errno = -ret;
+        return nullptr;
+    }
+    return new ErofsDir(dirs);
+}
+
+
+// ErofsDir
+ErofsDir::ErofsDir(std::vector<::dirent> &dirs) : loc(0) {
+        m_dirs = std::move(dirs);
+        next();
+}
+
+ErofsDir::~ErofsDir() {
+    closedir();
+}
+
+int ErofsDir::closedir() {
+    if (!m_dirs.empty()) {
+        m_dirs.clear();
+    }
+    return 0;
+}
+
+dirent *ErofsDir::get() {
+    return direntp;
+}
+
+int ErofsDir::next() {
+    if (!m_dirs.empty()) {
+        if (loc < (long) m_dirs.size()) {
+            direntp = &m_dirs[loc++];
+        } else {
+            direntp = nullptr;
+        }
+    }
+    return direntp != nullptr ? 1 : 0;
+}
+
+void ErofsDir::rewinddir() {
+    loc = 0;
+    next();
+}
+
+void ErofsDir::seekdir(long loc){
+    this->loc = loc;
+    next();
+}
+
+long ErofsDir::telldir() {
+    return loc;
+}
+
+bool erofs_check_fs(const photon::fs::IFile *imgfile)
+{
+	u8 data[EROFS_MAX_BLOCK_SIZE];
+	struct erofs_super_block *dsb;
+	photon::fs::IFile *file = const_cast<photon::fs::IFile *>(imgfile);
+	int ret;
+
+	ret = file->pread(data, EROFS_MAX_BLOCK_SIZE, 0);
+	if (ret != EROFS_MAX_BLOCK_SIZE)
+		LOG_ERROR_RETURN(-EIO, false, "[erofs] Fail to read superblock");
+	dsb = reinterpret_cast<struct erofs_super_block *>(data + EROFS_SUPER_OFFSET);
+	return le32_to_cpu(dsb->magic) == EROFS_SUPER_MAGIC_V1;
+}
+
+photon::fs::IFileSystem *erofs_create_fs(photon::fs::IFile *imgfile, uint64_t blksz)
+{
+    return new ErofsFileSystem(imgfile, blksz);
 }

--- a/src/overlaybd/tar/erofs/liberofs.h
+++ b/src/overlaybd/tar/erofs/liberofs.h
@@ -15,4 +15,8 @@ private:
     uint64_t blksize;
     bool ddtaridx;
 };
+
+bool erofs_check_fs(const photon::fs::IFile *imgfile);
+photon::fs::IFileSystem *erofs_create_fs(photon::fs::IFile *imgfile, uint64_t blksz);
+
 #endif

--- a/src/test/trace_test.cpp
+++ b/src/test/trace_test.cpp
@@ -12,6 +12,7 @@
 #include <string>
 #include "../overlaybd/gzip/gz.h"
 #include "../overlaybd/tar/libtar.h"
+#include "../overlaybd/tar/erofs/liberofs.h"
 #include "../prefetch.cpp"
 
 #include "../tools/comm_func.h"
@@ -28,6 +29,16 @@ const vector<pair<string, string>> fnlist = {
     {"overlaybd-1.0.12/src/image_file.h", "sha256:cb98584c50c031c3c3c08d1fc03ad05d733d57a31ec32249a8d1e5150f352528"},
     {"overlaybd-1.0.12/src/version.h", "sha256:5b216e936c66e971292ff720a4843d9a03bca13d5a8b5dd393c7bedca592ca73"},
     {"overlaybd-1.0.12/src/main.cpp", "sha256:4653edf45471096d549b2a002d2b10dafb5beb939cff3f1dfc936fb4d75c070a"}
+};
+
+const string erofs_imgs[]={"https://github.com/salvete/erofs-imgs/raw/main/alpine.img"};
+const vector<pair<string, string>> erofs_fnlist = {
+    {"/bin/busybox", "sha256:42de297577993675efecf295acf0260e26128458048b3081451e1ac43f611b49"},
+    {"/bin/sh", "sha256:42de297577993675efecf295acf0260e26128458048b3081451e1ac43f611b49"},
+    {"/lib/ld-musl-x86_64.so.1", "sha256:60d0ed88672b260b8337bf1e5b721f9ca9c877f4d901886472b8195a38ff3630"},
+    {"/lib/libc.musl-x86_64.so.1", "sha256:60d0ed88672b260b8337bf1e5b721f9ca9c877f4d901886472b8195a38ff3630"},
+    {"/lib/libz.so.1.3.1", "sha256:5134dcc47a23d1bfa7cd0f8046343e9268d4d3f1827dce295713d3b10ada5e0a"},
+    {"/lib/libz.so.1", "sha256:5134dcc47a23d1bfa7cd0f8046343e9268d4d3f1827dce295713d3b10ada5e0a"}
 };
 
 class MockFile : public ForwardFile_Ownership{
@@ -56,6 +67,16 @@ int download(const std::string &url, const std::string &out) {
     }
     return 0;
 }
+
+int download_erofs_img(const std::string &url, const std::string &out)
+{
+    std::string cmd = "wget -O" + out + " " + url;
+    auto ret = system(cmd.c_str());
+    if (ret != 0)
+        LOG_ERRNO_RETURN(0, -1, "download failed: `", url.c_str());
+    return 0;
+}
+
 TEST(trace, case0) {
 
     return;
@@ -131,6 +152,71 @@ TEST(trace, case0) {
     }
     delete p;
 }
+
+TEST(trace, case1) {
+    //return;
+    std::string workdir = "/tmp/trace_test/";
+    mkdir(workdir.c_str(), 0755);
+
+    std::string erofs_img_path = workdir + basename(erofs_imgs[0].c_str());
+    ASSERT_EQ(
+        0, download_erofs_img(erofs_imgs[0], erofs_img_path.c_str()));
+
+    auto dst = open_file(erofs_img_path.c_str(), O_RDONLY, 0644);
+    dst = new MockFile(dst);
+    DEFER(delete dst);
+
+    auto flist = open_file((workdir+"list").c_str(), O_CREAT|O_RDWR|O_TRUNC, 0644);
+    for (auto it : erofs_fnlist) {
+        auto fn = it.first + "\n";
+        flist->write(fn.c_str(), fn.size());
+    }
+    flist->write("/etc/\n", strlen("/etc/\n"));
+    delete flist;
+
+    auto fs = create_erofs_fs(dst, 4096);
+    ASSERT_NE(fs, nullptr);
+    DEFER(delete fs);
+
+    auto p = new_dynamic_prefetcher(workdir+"list", 8);
+    p->replay(dst);
+
+    for (auto fn: erofs_fnlist) {
+        vector<pair<off_t, uint64_t>> lba;
+        auto file = fs->open(fn.first.c_str(), O_RDONLY);
+        auto fout = open_file((workdir+"check").c_str(), O_CREAT|O_RDWR|O_TRUNC, 0644);
+        LOG_INFO("file_name: `", fn.first.c_str());
+        ASSERT_NE(file, nullptr);
+        DEFER(delete file);
+        struct stat buf;
+        file->fstat(&buf);
+        uint64_t size = buf.st_size;
+
+        photon::fs::fiemap_t<8192> fie(0, size);
+        ASSERT_EQ(file->fiemap(&fie), 0);
+        LOG_INFO("check ` size: `, extents: `", fn.first, size, fie.fm_mapped_extents);
+        // uint64_t count = ((size+ T_BLOCKSIZE - 1) / T_BLOCKSIZE) * T_BLOCKSIZE;
+        for (uint32_t i = 0; i < fie.fm_mapped_extents; i++) {
+            LOG_INFO("get segment: ` `", fie.fm_extents[i].fe_physical, fie.fm_extents[i].fe_length);
+            lba.push_back(make_pair(fie.fm_extents[i].fe_physical, fie.fm_extents[i].fe_length < size ? fie.fm_extents[i].fe_length : size));
+            size -= lba.back().second;
+        }
+        for (auto it : lba) {
+            char data[4<<20];
+            LOG_INFO("write segment: ` `", it.first, it.second);
+            dst->pread(data, it.second, it.first);
+            fout->write(data, it.second);
+        }
+        fout->lseek(0, SEEK_SET);
+        auto sha256file = new_sha256_file(fout, true);
+        DEFER(delete sha256file);
+        LOG_INFO("verify sha256 of `", fn.first);
+        ASSERT_STREQ(sha256file->sha256_checksum().c_str(), fn.second.c_str());
+    }
+
+    delete p;
+}
+
 
 
 int main(int argc, char **arg) {

--- a/src/tools/comm_func.cpp
+++ b/src/tools/comm_func.cpp
@@ -22,6 +22,7 @@
 #include <photon/fs/extfs/extfs.h>
 #include "../image_service.h"
 #include "../image_file.h"
+#include "../overlaybd/tar/erofs/liberofs.h"
 
 
 using namespace std;
@@ -77,4 +78,16 @@ photon::fs::IFileSystem *create_ext4fs(photon::fs::IFile *imgfile, bool mkfs,
         exit(-1);
     }
     return target;
+}
+
+bool is_erofs_fs(const photon::fs::IFile *imgfile)
+{
+    if (imgfile == nullptr)
+        LOG_ERRNO_RETURN(-EINVAL, false, "Imgfile is nullptr");
+    return erofs_check_fs(imgfile);
+}
+
+photon::fs::IFileSystem *create_erofs_fs(photon::fs::IFile *imgfile, uint64_t blksz)
+{
+    return erofs_create_fs(imgfile, blksz);
 }

--- a/src/tools/comm_func.h
+++ b/src/tools/comm_func.h
@@ -43,3 +43,6 @@ int create_overlaybd(const std::string &srv_config, const std::string &dev_confi
 
 photon::fs::IFileSystem *create_ext4fs(photon::fs::IFile *imgfile, bool mkfs,
     bool enable_buffer, const char* root);
+
+bool is_erofs_fs(const photon::fs::IFile *imgfile);
+photon::fs::IFileSystem *create_erofs_fs(photon::fs::IFile *imgfile, uint64_t blksz);


### PR DESCRIPTION
**What this PR does / why we need it**:
1. Remove the global variables `_target` and `_source`, and introduce `struct liberofs_file` to wrap the source and target files.
2. Introduce prefetch feature.

The corresponding accelerated-container-image PR:
https://github.com/containerd/accelerated-container-image/pull/299

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Please check the following list**:
- [ ]  Does the affected code have corresponding tests, e.g. unit test, E2E test?
- [ ]  Does this change require a documentation update?
- [ ]  Does this introduce breaking changes that would require an announcement or bumping the major version?
- [ ]  Do all new files have an appropriate license header?

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues directly to https://github.com/containerd/overlaybd/blob/main/MAINTAINERS. -->
