### PR TITLE
[feat.] a new tool 'overlaybd-merge'

### DIFF
--- a/src/image_file.cpp
+++ b/src/image_file.cpp
@@ -520,8 +520,6 @@ int ImageFile::compact(IFile *as) {
     return ((LSMT::IFileRO*)m_file)->flatten(as);
 }
 
-
-
 void ImageFile::set_auth_failed() {
     if (m_status == 0) // only set exit in image boot phase
     {

--- a/src/image_file.cpp
+++ b/src/image_file.cpp
@@ -28,6 +28,7 @@
 #include <photon/fs/aligned-file.h>
 #include <photon/fs/localfs.h>
 #include "overlaybd/lsmt/file.h"
+#include "overlaybd/lsmt/index.h"
 #include "overlaybd/zfile/zfile.h"
 #include "config.h"
 #include "image_file.h"
@@ -514,6 +515,12 @@ ERROR_EXIT:
     delete upper_file;
     return -1;
 }
+
+int ImageFile::compact(IFile *as) {
+    return ((LSMT::IFileRO*)m_file)->flatten(as);
+}
+
+
 
 void ImageFile::set_auth_failed() {
     if (m_status == 0) // only set exit in image boot phase

--- a/src/image_file.h
+++ b/src/image_file.h
@@ -109,6 +109,8 @@ public:
         return m_file;
     }
 
+    int compact(IFile *as);
+
 private:
     Prefetcher *m_prefetcher = nullptr;
     ImageConfigNS::ImageConfig conf;
@@ -126,5 +128,7 @@ private:
     IFile *__open_ro_target_file(const std::string &);
     IFile *__open_ro_remote(const std::string &dir, const std::string &, const uint64_t, int);
     IFile *__open_ro_target_remote(const std::string &dir, const std::string &, const uint64_t, int);
+
+    // size_t seek_data(off_t begin, off_t end);
     void start_bk_dl_thread();
 };

--- a/src/image_service.h
+++ b/src/image_service.h
@@ -58,6 +58,7 @@ public:
     // bool enable_acceleration(GlobalFs *global_fs, ImageConfigNS::P2PConfig conf);
     bool enable_acceleration();
 
+
     ImageConfigNS::GlobalConfig global_conf;
     struct GlobalFs global_fs;
     std::unique_ptr<OverlayBDMetric> metrics;

--- a/src/overlaybd/lsmt/file.h
+++ b/src/overlaybd/lsmt/file.h
@@ -50,6 +50,11 @@ public:
     virtual int get_uuid(UUID &out, size_t layer_idx = 0) const = 0;
 
     virtual std::vector<IFile *> get_lower_files() const = 0;
+
+    virtual ssize_t seek_data(off_t begin, off_t end, std::vector<Segment> &segs) = 0;
+
+    virtual int flatten(IFile *as) = 0;
+
 };
 
 struct CommitArgs {
@@ -96,6 +101,7 @@ public:
         uint64_t valid_data_size = -1; // size of valid data (excluding garbage)
     };
     virtual DataStat data_stat() const = 0;
+
 };
 
 // create a new writable LSMT file constitued by a data file and an index file,

--- a/src/overlaybd/lsmt/file.h
+++ b/src/overlaybd/lsmt/file.h
@@ -75,7 +75,6 @@ struct CommitArgs {
 class IFileRW : public IFileRO {
 public:
     virtual IMemoryIndex0 *index() const override = 0;
-
     const int Index_Group_Commit = 10;
 
     static const int RemoteData = 11;

--- a/src/overlaybd/lsmt/index.cpp
+++ b/src/overlaybd/lsmt/index.cpp
@@ -153,6 +153,8 @@ public:
     uint64_t vsize() const override {
         return virtual_size;
     }
+
+    UNIMPLEMENTED_POINTER(IMemoryIndex  *make_read_only_index() const override);
 };
 
 class LevelIndex : public Index {
@@ -253,6 +255,8 @@ public:
             m_alloc = m_alloc + m.length;
         }
     } alloc_blk;
+
+    // Index0(const set<SegmentMapping> &mapping) : mapping(mapping){};
 
     Index0(const SegmentMapping *pmappings = nullptr, size_t n = 0) {
         if (pmappings == nullptr)
@@ -505,6 +509,21 @@ public:
         merge_indexes(0, mappings, indexes, 2, 0, UINT64_MAX, false, max_level);
         return new Index(std::move(mappings));
     }
+
+     virtual Index *make_read_only_index() const override{
+        vector<SegmentMapping> mappings;
+        auto ro_idx0 = new Index;
+        ro_idx0->ownership = false;
+        ro_idx0->assign(mapping.begin(), mapping.end());
+        if (m_backing_index == nullptr) {
+            return ro_idx0;
+        }
+        const Index *indexes[2] = {ro_idx0, const_cast<Index *>(m_backing_index)};
+        merge_indexes(0, mappings, indexes, 2, 0, UINT64_MAX, false, 2);
+        delete ro_idx0;
+        return new Index(std::move(mappings));
+    }
+
 };
 
 //======================== END OF ComboIndex =============================//

--- a/src/overlaybd/lsmt/index.h
+++ b/src/overlaybd/lsmt/index.h
@@ -128,6 +128,8 @@ public:
     virtual uint64_t block_count() const = 0;
 
     virtual uint64_t vsize() const = 0;
+
+    virtual IMemoryIndex *make_read_only_index() const = 0;
 };
 
 // the level 0 memory index, which supports write
@@ -139,7 +141,7 @@ public:
     // dump the the whole index as an array
     // memory allocation is aligned to the `alignment`
     virtual SegmentMapping *dump(size_t alignment = 0) const = 0;
-    virtual IMemoryIndex *make_read_only_index() const = 0;
+    // virtual IMemoryIndex *make_read_only_index() const = 0;
 };
 
 class IComboIndex : public IMemoryIndex0 {
@@ -153,6 +155,8 @@ public:
     // and then clear the original index0.
     // virtual IMemoryIndex0* gc_index() = 0;
     virtual IMemoryIndex *load_range_index(int, int) const = 0;
+
+
 };
 
 // create writable level 0 memory index from an array of mappings;

--- a/src/tools/CMakeLists.txt
+++ b/src/tools/CMakeLists.txt
@@ -2,6 +2,11 @@ add_executable(overlaybd-commit overlaybd-commit.cpp)
 target_include_directories(overlaybd-commit PUBLIC ${PHOTON_INCLUDE_DIR})
 target_link_libraries(overlaybd-commit photon_static overlaybd_image_lib)
 
+add_executable(overlaybd-merge overlaybd-merge.cpp)
+target_include_directories(overlaybd-merge PUBLIC ${PHOTON_INCLUDE_DIR})
+target_link_libraries(overlaybd-merge photon_static overlaybd_image_lib)
+
+
 add_executable(overlaybd-create overlaybd-create.cpp)
 target_include_directories(overlaybd-create PUBLIC ${PHOTON_INCLUDE_DIR})
 target_link_libraries(overlaybd-create photon_static overlaybd_lib)
@@ -30,6 +35,8 @@ install(TARGETS
     overlaybd-create
     overlaybd-zfile
     overlaybd-apply
+    overlaybd-merge
+
     turboOCI-apply
     DESTINATION /opt/overlaybd/bin
 )

--- a/src/tools/overlaybd-merge.cpp
+++ b/src/tools/overlaybd-merge.cpp
@@ -1,0 +1,132 @@
+/*
+   Copyright The Overlaybd Authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+#include <photon/common/alog.h>
+#include <photon/fs/localfs.h>
+#include <photon/fs/subfs.h>
+#include <photon/fs/virtual-file.h>
+#include <photon/fs/extfs/extfs.h>
+#include <photon/photon.h>
+#include "../overlaybd/lsmt/file.h"
+#include "../overlaybd/zfile/zfile.h"
+#include "../overlaybd/tar/libtar.h"
+#include "../overlaybd/gzindex/gzfile.h"
+#include "../overlaybd/gzip/gz.h"
+#include <errno.h>
+#include <fcntl.h>
+#include <inttypes.h>
+#include <memory>
+#include <string>
+#include <stdio.h>
+#include <stdlib.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <unistd.h>
+#include "../image_service.h"
+#include "../image_file.h"
+#include "CLI11.hpp"
+#include "comm_func.h"
+#include "sha256file.h"
+
+using namespace std;
+using namespace photon::fs;
+
+class FIFOFile : public VirtualReadOnlyFile {
+public:
+    IFile *m_fifo;
+
+    FIFOFile(IFile *fifo): m_fifo(fifo) { }
+    ~FIFOFile() { delete m_fifo; }
+
+    ssize_t read(void *buf, size_t count) override {
+        size_t left = count;
+        char *pos = (char *) buf;
+        LOG_DEBUG(VALUE(count));
+        while (left > 0) {
+            ssize_t readn = m_fifo->read(pos, left);
+            if (readn < 0 || readn > (ssize_t) left) {
+                LOG_ERRNO_RETURN(0, -1, "failed to read fifo", VALUE(left), VALUE(readn));
+            }
+            left -= (size_t) readn;
+            pos += readn;
+            LOG_DEBUG("fifo read", VALUE(readn));
+        }
+        LOG_DEBUG(VALUE(left));
+        return count - left;
+    }
+
+    int fstat(struct stat *buf) override {
+        return m_fifo->fstat(buf);
+    }
+
+    UNIMPLEMENTED_POINTER(IFileSystem *filesystem() override);
+    UNIMPLEMENTED(off_t lseek(off_t offset, int whence) override);
+    UNIMPLEMENTED(ssize_t readv(const struct iovec *iov, int iovcnt) override);
+    UNIMPLEMENTED(ssize_t preadv(const struct iovec *iov, int iovcnt, off_t offset) override);
+};
+
+int main(int argc, char **argv) {
+    std::string image_config_path, input_path, output, config_path, sha256_checksum;
+    string tarheader;
+    bool zfile = false, mkfs = false, verbose = false, raw = false;
+
+    CLI::App app{"this is overlaybd-merge, merge multiple overlaybd layers into a single."};
+
+    app.add_flag("--verbose", verbose, "output debug info")->default_val(false);
+    app.add_option("--service_config_path", config_path, "overlaybd image service config path")->type_name("FILEPATH")->check(CLI::ExistingFile)->default_val("/etc/overlaybd/overlaybd.json");
+    app.add_flag("--compress", zfile, "do zfile compression for the output layer")->default_val(true);
+
+    app.add_option("image_config_path", image_config_path, "overlaybd image config path")->type_name("FILEPATH")->check(CLI::ExistingFile)->required();
+    app.add_option("output", output, "compacted layer path")->type_name("FILEPATH");
+
+    CLI11_PARSE(app, argc, argv);
+
+    set_log_output_level(verbose ? 0 : 1);
+    photon::init(photon::INIT_EVENT_DEFAULT, photon::INIT_IO_DEFAULT);
+    DEFER({photon::fini();});
+
+
+    ImageService *imgservice = nullptr;
+    photon::fs::IFile *imgfile = nullptr;
+    create_overlaybd(config_path, image_config_path, imgservice, imgfile);
+    if (imgfile == nullptr) {
+        fprintf(stderr, "failed to create image file\n");
+        exit(-1);
+    }
+     DEFER({
+        delete imgfile;
+        delete imgservice;
+    });
+    auto rst = open_localfile_adaptor(output.c_str(), O_CREAT|O_TRUNC|O_RDWR, 0644);
+    if (rst == nullptr){
+        fprintf(stderr, "failed to create output file\n");
+        exit(-1);
+    }
+    DEFER(delete rst);
+    if (zfile) {
+        rst = ZFile::new_zfile_builder(rst);
+        if (rst == nullptr) {
+            fprintf(stderr, "failed to create zfile\n");
+            exit(-1);
+        }
+    }
+    if (((ImageFile*)imgfile)->compact(rst)!=0){
+        fprintf(stderr, "failed to compact\n");
+        exit(-1);
+    }
+
+    return 0;
+}


### PR DESCRIPTION
We are providing a tool named 'overlaybd-merge' that can compact an overlaybd image with multiple layers into a single layer.

And replacing a single read for ZFile index with parallel loading.

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #345 

**Please check the following list**:
- [x]  Does the affected code have corresponding tests, e.g. unit test, E2E test?
- [ ]  Does this change require a documentation update?
- [ ]  Does this introduce breaking changes that would require an announcement or bumping the major version?
- [ ]  Do all new files have an appropriate license header?

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues directly to https://github.com/containerd/overlaybd/blob/main/MAINTAINERS. -->
