### PR TITLE
[EROFS] Align with the block size of overlayBD

### DIFF
--- a/src/overlaybd/tar/erofs/CMakeLists.txt
+++ b/src/overlaybd/tar/erofs/CMakeLists.txt
@@ -3,7 +3,7 @@ include(FetchContent)
 FetchContent_Declare(
     erofs-utils
     GIT_REPOSITORY https://git.kernel.org/pub/scm/linux/kernel/git/xiang/erofs-utils.git
-    GIT_TAG        ac0997ea32a465a6b0db7b782bb8d4d07952365a
+    GIT_TAG        7642e38f12785105262cccb584f724a22c0f9c77
 )
 
 FetchContent_MakeAvailable(erofs-utils)


### PR DESCRIPTION
The inconsistency in the default block sizes between OverlayBD and EROFS can lead to issues during segment mapping. This patch aligns with the block size of overlaybd for mapping (i.e., OverlayBD's 512-byte size) to overcome this inconsistency.

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Please check the following list**:
- [ ]  Does the affected code have corresponding tests, e.g. unit test, E2E test?
- [ ]  Does this change require a documentation update?
- [ ]  Does this introduce breaking changes that would require an announcement or bumping the major version?
- [ ]  Do all new files have an appropriate license header?

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues directly to https://github.com/containerd/overlaybd/blob/main/MAINTAINERS. -->
