### PR TITLE
 Align with the block size of overlayBD

### DIFF
--- a/src/overlaybd/tar/erofs/CMakeLists.txt
+++ b/src/overlaybd/tar/erofs/CMakeLists.txt
@@ -3,7 +3,7 @@ include(FetchContent)
 FetchContent_Declare(
     erofs-utils
     GIT_REPOSITORY https://git.kernel.org/pub/scm/linux/kernel/git/xiang/erofs-utils.git
-    GIT_TAG        ac0997ea32a465a6b0db7b782bb8d4d07952365a
+    GIT_TAG        654e8b8a8f1a87b0746ff47db00dec1afc05fbc9
 )
 
 FetchContent_MakeAvailable(erofs-utils)

--- a/src/overlaybd/tar/erofs/liberofs.cpp
+++ b/src/overlaybd/tar/erofs/liberofs.cpp
@@ -624,7 +624,7 @@ int LibErofs::extract_tar(photon::fs::IFile *source, bool meta_only, bool first_
     struct erofs_mkfs_cfg mkfs_cfg;
     struct erofs_configure *erofs_cfg;
     struct liberofs_file target_file, source_file;
-    int err;
+    int err, err2;
 
     target_file.ops.pread = erofs_target_pread;
     target_file.ops.pwrite = erofs_target_pwrite;
@@ -690,11 +690,11 @@ int LibErofs::extract_tar(photon::fs::IFile *source, bool meta_only, bool first_
         goto exit;
     }
 exit:
-    err = erofs_close_sbi(&sbi, target_file.cache);
+    err2 = erofs_close_sbi(&sbi, target_file.cache);
     erofs_close_tar(&erofstar);
     std::fclose(mkfs_cfg.mp_fp);
     delete target_file.cache;
-    return err;
+    return err ? err : err2;
 }
 
 LibErofs::LibErofs(photon::fs::IFile *target, uint64_t blksize, bool import_tar_headers)


### PR DESCRIPTION
**What this PR does / why we need it**:

The inconsistency in the default block sizes between OverlayBD and EROFS can lead to issues during segment mapping. This patch aligns with the block size of overlaybd for mapping (i.e., OverlayBD's 512-byte size) to overcome this inconsistency.



**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Please check the following list**:
- [ ]  Does the affected code have corresponding tests, e.g. unit test, E2E test?
- [ ]  Does this change require a documentation update?
- [ ]  Does this introduce breaking changes that would require an announcement or bumping the major version?
- [ ]  Do all new files have an appropriate license header?

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues directly to https://github.com/containerd/overlaybd/blob/main/MAINTAINERS. -->
