### PR TITLE
[EROFS] fix the loss of uid and gid

### DIFF
--- a/src/overlaybd/tar/erofs/CMakeLists.txt
+++ b/src/overlaybd/tar/erofs/CMakeLists.txt
@@ -3,7 +3,7 @@ include(FetchContent)
 FetchContent_Declare(
     erofs-utils
     GIT_REPOSITORY https://git.kernel.org/pub/scm/linux/kernel/git/xiang/erofs-utils.git
-    GIT_TAG        80156068eb4980342c0ad3ee47ac7261acce5caf
+    GIT_TAG        eec6f7a2755dfccc8f655aa37cf6f26db9164e60
 )
 
 FetchContent_MakeAvailable(erofs-utils)

--- a/src/overlaybd/tar/erofs/liberofs.cpp
+++ b/src/overlaybd/tar/erofs/liberofs.cpp
@@ -25,6 +25,8 @@ struct erofs_mkfs_cfg {
 
 static int rebuild_src_count;
 
+extern void erofs_init_configure(void);
+
 int erofs_mkfs(struct erofs_mkfs_cfg *mkfs_cfg)
 {
     int err;
@@ -280,6 +282,7 @@ int LibErofs::extract_tar(photon::fs::IFile *source, bool meta_only, bool first_
     mkfs_cfg.sbi = &sbi;
     mkfs_cfg.erofstar = &erofstar;
     mkfs_cfg.incremental = !first_layer;
+    erofs_init_configure();
     erofs_cfg = erofs_get_configure();
     erofs_cfg->c_ovlfs_strip = true;
     if (first_layer)


### PR DESCRIPTION
Currently, the uid and gid in the tar file are
lost because the `c_uid` and `c_gid` of `erofs_cfg` are not set to -1.

This patch fixes it.

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Please check the following list**:
- [ ]  Does the affected code have corresponding tests, e.g. unit test, E2E test?
- [ ]  Does this change require a documentation update?
- [ ]  Does this introduce breaking changes that would require an announcement or bumping the major version?
- [ ]  Do all new files have an appropriate license header?

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues directly to https://github.com/containerd/overlaybd/blob/main/MAINTAINERS. -->
