### PR TITLE
fix and enhance dynamic prefetcher

### DIFF
--- a/src/image_file.h
+++ b/src/image_file.h
@@ -42,7 +42,7 @@ static std::string SEALED_FILE_NAME = "overlaybd.sealed";
 class ImageFile : public photon::fs::ForwardFile {
 public:
     ImageFile(ImageConfigNS::ImageConfig &_conf, ImageService &is)
-        : ForwardFile(nullptr), image_service(is) {
+        : ForwardFile(nullptr), image_service(is), m_lower_file(nullptr) {
         conf.CopyFrom(_conf, conf.GetAllocator());
         m_exception = "";
         m_status = init_image_file();
@@ -61,6 +61,9 @@ public:
         if (m_file) {
             m_file->close();
             delete m_file;
+        }
+        if (m_lower_file) {
+            delete m_lower_file;
         }
     }
 
@@ -117,6 +120,7 @@ private:
     std::list<BKDL::BkDownload *> dl_list;
     photon::join_handle *dl_thread_jh = nullptr;
     ImageService &image_service;
+    photon::fs::IFile *m_lower_file = nullptr;
 
     int init_image_file();
     template<typename...Ts> void set_failed(const Ts&...xs);

--- a/src/overlaybd/gzindex/gzfile.cpp
+++ b/src/overlaybd/gzindex/gzfile.cpp
@@ -28,6 +28,7 @@
 #include "photon/photon.h"
 #include "photon/fs/virtual-file.h"
 #include "photon/common/checksum/crc32c.h"
+#include "photon/thread/thread.h"
 
 namespace FileSystem {
 using namespace photon::fs;
@@ -62,6 +63,7 @@ private:
     struct IndexFileHeader index_header_;
     INDEX index_;
     bool inited_ = false;
+    photon::mutex init_mutex_;
     int init();
     int parse_index();
     IndexEntry *seek_index(INDEX &index, off_t offset);
@@ -142,6 +144,7 @@ int GzFile::parse_index() {
 }
 
 int GzFile::init() {
+    SCOPED_LOCK(init_mutex_);
     if (inited_) {
         return 0;
     }

--- a/src/prefetch.cpp
+++ b/src/prefetch.cpp
@@ -29,16 +29,18 @@ limitations under the License.
 #include "prefetch.h"
 #include "tools/comm_func.h"
 #include "overlaybd/lsmt/file.h"
+#include "overlaybd/zfile/crc32/crc32c.h"
+
 #include <photon/common/alog.h>
 #include <photon/common/alog-stdstring.h>
 #include <photon/fs/forwardfs.h>
 #include <photon/fs/localfs.h>
 #include <photon/thread/thread11.h>
-#include "overlaybd/zfile/crc32/crc32c.h"
-#include "photon/fs/filesystem.h"
-#include "photon/fs/fiemap.h"
-#include "photon/fs/path.h"
-#include "photon/common/enumerable.h"
+#include <photon/fs/filesystem.h>
+#include <photon/fs/fiemap.h>
+#include <photon/fs/path.h>
+#include <photon/common/enumerable.h>
+#include <photon/fs/extfs/extfs.h>
 
 
 using namespace std;
@@ -370,7 +372,7 @@ public:
         while (start <= end && str[start] == c) {
             ++start;
         }
-        while (end >= start && str[start] == c) {
+        while (end >= start && str[end] == c) {
             --end;
         }
         return str.substr(start, end - start + 1);
@@ -394,7 +396,7 @@ public:
         file.seekg(0, ios::beg);
         std::string line;
         while (std::getline(file, line)) {
-            line = trim(trim(line, ' '), '/');
+            line = trim(line, ' ');
             if (line.empty() || !invalid_abs_path(line)) {
                 continue;
             }
@@ -470,7 +472,7 @@ public:
         if (fstype == "erofs")
             fs = create_erofs_fs(const_cast<IFile*>(imagefile), 4096);
         else
-            fs = create_ext4fs(const_cast<IFile*>(imagefile), false, true, "/");
+            fs = new_extfs(const_cast<IFile*>(imagefile), true);
 
         if (fs == nullptr) {
             LOG_ERROR_RETURN(0, -1, "unrecognized filesystem in dynamic prefetcher");


### PR DESCRIPTION
**What this PR does / why we need it**:
- Prefetcher should use the readonly lower_file but not the m_file, or some error will occur when using upper layer and dynamic prefetcher together.
- Fix the way to resolve filepath, now we could use '/' as a prefetch item.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Please check the following list**:
- [ ]  Does the affected code have corresponding tests, e.g. unit test, E2E test?
- [ ]  Does this change require a documentation update?
- [ ]  Does this introduce breaking changes that would require an announcement or bumping the major version?
- [ ]  Do all new files have an appropriate license header?

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues directly to https://github.com/containerd/overlaybd/blob/main/MAINTAINERS. -->
