### PR TITLE
Fix CI & upper layer bug

### DIFF
--- a/.github/workflows/project-checks.yml
+++ b/.github/workflows/project-checks.yml
@@ -25,7 +25,50 @@ jobs:
           path: src/github.com/containerd/overlaybd
           fetch-depth: 100
 
-      - name: Project checks
-        uses: containerd/project-checks@v1.1.0
-        with:
-          working-directory: src/github.com/containerd/overlaybd
+      - name: set env
+        shell: bash
+        run: |
+          echo "GOPATH=${{ github.workspace }}" >> $GITHUB_ENV
+          echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
+
+      - name: Install dependencies
+        shell: bash
+        env:
+          GO111MODULE: on
+        run: |
+          echo "::group::🚧 Get dependencies"
+          go install -v github.com/vbatts/git-validation@latest
+          go install -v github.com/containerd/ltag@latest
+          echo "::endgroup::"
+
+      - name: DCO Checks
+        shell: bash
+        working-directory: src/github.com/containerd/overlaybd
+        env:
+          GITHUB_COMMIT_URL: ${{ github.event.pull_request.commits_url }}
+          REPO_ACCESS_TOKEN: ""
+          DCO_VERBOSITY: "-v"
+          DCO_RANGE: ""
+        run: |
+          echo "::group::👮 DCO checks"
+          set -x
+          if [[ ! -z "${REPO_ACCESS_TOKEN}" ]]; then
+          HEADERS=(-H "Accept: application/vnd.github+json" -H "Authorization: Bearer ${REPO_ACCESS_TOKEN}")
+          else
+          HEADERS=(-H "Accept: application/vnd.github+json")
+          fi
+          if [ -z "${GITHUB_COMMIT_URL}" ]; then
+          DCO_RANGE=$(jq -r '.after + "..HEAD"' ${GITHUB_EVENT_PATH})
+          else
+          DCO_RANGE=$(curl "${HEADERS[@]}" ${GITHUB_COMMIT_URL} | jq -r '.[0].parents[0].sha + "..HEAD"')
+          fi
+          git-validation ${DCO_VERBOSITY} ${DCO_RANGE} -run DCO,short-subject,dangling-whitespace
+          echo "::endgroup::"
+
+      - name: Validate file headers
+        shell: bash
+        working-directory: src/github.com/containerd/overlaybd
+        run: |
+          echo "::group::📚 File headers"
+          ltag -t "script/validate/template" --excludes "vendor contrib" --check -v
+          echo "::endgroup::"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -84,10 +84,17 @@ jobs:
         ls -l releases/
       env:
         IMAGE: ${{ matrix.images }}
+    - id: upload_name
+      name: Upload name
+      run: |
+        image=${{ matrix.images }}
+        platform=${{ matrix.platforms }}
+        name="releases-${image//\//_}-${platform/\//_}"
+        echo "name=${name}" >> "$GITHUB_OUTPUT"
     - name: Upload
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
-        name: releases
+        name: ${{ steps.upload_name.outputs.name }}
         path: releases/overlaybd-*.*
 
   dev-release:
@@ -97,7 +104,7 @@ jobs:
     needs: [build]
     steps:
       - name: Download builds and release notes
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
       - name: Display downloaded files
         shell: bash
         run: ls -l releases
@@ -118,7 +125,7 @@ jobs:
     needs: [build]
     steps:
       - name: Download builds and release notes
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
       - name: Display downloaded files
         shell: bash
         run: ls -l releases

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,10 +31,10 @@ jobs:
       uses: actions/checkout@v3
       with:
         submodules: true
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@v3
     - name: Setup buildx instance
-      uses: docker/setup-buildx-action@v2
-      with:
-        use: true
+      uses: docker/setup-buildx-action@v3
     - name: Build
       shell: bash
       run: |

--- a/src/image_file.h
+++ b/src/image_file.h
@@ -62,9 +62,8 @@ public:
             m_file->close();
             delete m_file;
         }
-        if (m_lower_file) {
-            delete m_lower_file;
-        }
+        if (m_lower_file) delete m_lower_file;
+        if (m_upper_file) delete m_upper_file;
     }
 
     int fstat(struct stat *buf) override {
@@ -121,6 +120,7 @@ private:
     photon::join_handle *dl_thread_jh = nullptr;
     ImageService &image_service;
     photon::fs::IFile *m_lower_file = nullptr;
+    photon::fs::IFile *m_upper_file = nullptr;
 
     int init_image_file();
     template<typename...Ts> void set_failed(const Ts&...xs);

--- a/src/overlaybd/lsmt/file.cpp
+++ b/src/overlaybd/lsmt/file.cpp
@@ -1807,7 +1807,7 @@ IFileRW *stack_files(IFileRW *upper_layer, IFileRO *lower_layers, bool ownership
         rst = new LSMTWarpFile;
         delta++;
     }
-    idx = create_combo_index((IMemoryIndex0 *)u->m_index, l->m_index, l->m_files.size(), true);
+    idx = create_combo_index((IMemoryIndex0 *)u->m_index, l->m_index, l->m_files.size(), ownership);
     rst->m_index = idx;
     rst->m_findex = u->m_findex;
     rst->m_vsize = u->m_vsize;
@@ -1830,9 +1830,9 @@ IFileRW *stack_files(IFileRW *upper_layer, IFileRO *lower_layers, bool ownership
     }
     rst->m_uuid.push_back(u->m_uuid[0]);
     rst->m_rw_tag = rst->m_files.size() - delta;
-    u->m_index = l->m_index = nullptr;
-    l->m_file_ownership = u->m_file_ownership = false;
     if (ownership) {
+        u->m_index = l->m_index = nullptr;
+        l->m_file_ownership = u->m_file_ownership = false;
         delete u;
         delete l;
     }

--- a/src/overlaybd/tar/erofs/test/erofs_stress_base.cpp
+++ b/src/overlaybd/tar/erofs/test/erofs_stress_base.cpp
@@ -352,7 +352,7 @@ LSMT::IFileRW *StressBase::mkfs()
 
 		LSMT::IFileRW *img_file = nullptr;
 		if (i > 0)
-			img_file = LSMT::stack_files(current_layer, lowers, false, false);
+			img_file = LSMT::stack_files(current_layer, lowers, true, false);
 		else
 			img_file = current_layer;
 
@@ -362,7 +362,6 @@ LSMT::IFileRW *StressBase::mkfs()
 			delete img_file;
 			LOG_ERROR_RETURN(-1, nullptr, "fail to extract tar");
 		}
-		delete lowers;
 		delete tar;
 		lowers = img_file;
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
- fix CI
  - artifact actions v3 has been deprecated, so we have to migrated to v4.
  - project checks v1.1.0 is no longer work but v1.2.0 is not available for c++ projects (v1.2.0 does go-licenses check ...).
  - fix arm build, see also https://github.com/tonistiigi/binfmt/issues/215.
- fix upper layer bug: some error occured when using upper layer. 
  - When using dynamic prefetcher with RW mode (have both lower and upper), the prefetcher will be failed to read from lower.
  - When using some image_file with upper only, overlaybd could be segfault.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Please check the following list**:
- [ ]  Does the affected code have corresponding tests, e.g. unit test, E2E test?
- [ ]  Does this change require a documentation update?
- [ ]  Does this introduce breaking changes that would require an announcement or bumping the major version?
- [ ]  Do all new files have an appropriate license header?

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues directly to https://github.com/containerd/overlaybd/blob/main/MAINTAINERS. -->
