### PR TITLE
Fix yaml-cpp dependency, as it is installed with that name, not yamlcpp

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -49,14 +49,14 @@ option(BUILD_CURL_FROM_SOURCE "Compile static libcurl" off)
 option(ORIGIN_EXT2FS "Use original libext2fs" off)
 find_package(photon REQUIRED)
 find_package(tcmu REQUIRED)
-find_package(yamlcpp)
-if (NOT yamlcpp_FOUND)
+find_package(yaml-cpp)
+if (NOT yaml-cpp_FOUND)
   FetchContent_Declare(
-    yamlcpp
+    yaml-cpp
     GIT_REPOSITORY https://github.com/jbeder/yaml-cpp.git
     GIT_TAG 0.8.0
   )
-  FetchContent_MakeAvailable(yamlcpp)
+  FetchContent_MakeAvailable(yaml-cpp)
 endif()
 
 


### PR DESCRIPTION
It was always fetching yaml-cpp, even when it was installed system-wide.

**Please check the following list**:
- [ ]  Does the affected code have corresponding tests, e.g. unit test, E2E test? N/A
- [ ]  Does this change require a documentation update? N/A
- [ ]  Does this introduce breaking changes that would require an announcement or bumping the major version? N/A
- [ ]  Do all new files have an appropriate license header? N/A