### PR TITLE
Pin libtcmu git tag rather than pointing at the main branch

### DIFF
--- a/CMake/Findtcmu.cmake
+++ b/CMake/Findtcmu.cmake
@@ -4,7 +4,7 @@ set(FETCHCONTENT_QUIET false)
 FetchContent_Declare(
   tcmu
   GIT_REPOSITORY https://github.com/data-accelerator/photon-libtcmu.git
-  GIT_TAG main
+  GIT_TAG 813fd65361bb2f348726b9c41478a44211847614
 )
 
 if(BUILD_TESTING)


### PR DESCRIPTION
Having CMake fetch dependencies live is not helpful for distributions, but it should at least not point to a moving target. All the other live dependencies are already pinned.

**Please check the following list**:
- [ ]  Does the affected code have corresponding tests, e.g. unit test, E2E test? N/A
- [ ]  Does this change require a documentation update? N/A
- [ ]  Does this introduce breaking changes that would require an announcement or bumping the major version? N/A
- [ ]  Do all new files have an appropriate license header? N/A