### PR TITLE
Fix netlink buffer overflow for concurrent TCMU

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -35,6 +35,7 @@
 #include <scsi/scsi.h>
 #include <sys/resource.h>
 #include <sys/prctl.h>
+#include <linux/netlink.h>
 #include <string>
 
 class TCMUDevLoop;
@@ -87,6 +88,32 @@ public:
         : ctx(ctx),
           loop(new_event_loop({this, &TCMULoop::wait_for_readable}, {this, &TCMULoop::on_accept})) {
         fd = tcmulib_get_master_fd(ctx);
+
+        // libnl3 defaults the socket receive buffer to 32KB which can be 
+        // overrun during concurrent device creation. This causes
+        // TCMU_CMD_ADDED_DEVICE messages to be silently dropped and leaves 
+        // kernel threads stuck in tcmu_wait_genl_cmd_reply().
+        // SO_RCVBUFFORCE requires CAP_NET_ADMIN (the daemon runs as root).
+        static constexpr int NETLINK_RCVBUF_SIZE = 4 * 1024 * 1024;
+        int rcvbuf = NETLINK_RCVBUF_SIZE;
+        if (setsockopt(fd, SOL_SOCKET, SO_RCVBUFFORCE,
+                        &rcvbuf, sizeof(rcvbuf)) < 0) {
+            LOG_ERROR("setsockopt(SO_RCVBUFFORCE) failed: `. "
+                      "Netlink buffer remains at libnl3 default (32KB); "
+                      "concurrent device creation may cause kernel hangs.",
+                      strerror(errno));
+        }
+
+        // NETLINK_NO_ENOBUFS prevents netlink_overrun() from setting
+        // the NETLINK_S_CONGESTED sticky flag on the socket. Without this,
+        // a single buffer-full event poisons all future deliveries until
+        // the buffer fully drains, cascading the original drop into a
+        // complete stall.
+        int no_enobufs = 1;
+        if (setsockopt(fd, SOL_NETLINK, NETLINK_NO_ENOBUFS,
+                        &no_enobufs, sizeof(no_enobufs)) < 0) {
+            LOG_WARN("setsockopt(NETLINK_NO_ENOBUFS) failed: `", strerror(errno));
+        }
     }
 
     ~TCMULoop() {


### PR DESCRIPTION
**What this PR does / why we need it**:

With default libnl3 buffer size (32kb) and NETLINK_S_CONGESTED flag, creating >50 TCMU devices in parallel causes kernel hangs and devices to never be set up. This is because the genlmsg_multicast_allns() notifications are silently dropped from a full buffer. This fix increases the buffer size and also prevents a single buffer-full event from poisoning subsequent deliveries into the buffer.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #398 

**Please check the following list**:
- [ ]  Does the affected code have corresponding tests, e.g. unit test, E2E test?
- [ ]  Does this change require a documentation update?
- [ ]  Does this introduce breaking changes that would require an announcement or bumping the major version?
- [ ]  Do all new files have an appropriate license header?

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues directly to https://github.com/containerd/overlaybd/blob/main/MAINTAINERS. -->
