### PR TITLE
fix(cache): cap actualEvict by totalUsed_ to prevent eviction deadloop

### DIFF
--- a/src/overlaybd/cache/full_file_cache/cache_pool.cpp
+++ b/src/overlaybd/cache/full_file_cache/cache_pool.cpp
@@ -215,7 +215,7 @@ void FileCachePool::eviction() {
     isFull_ = true;
 
     if (!lru_.empty() && !exit_) {
-        LOG_INFO("start eviction ", VALUE(actualEvict), VALUE(evictByCache), VALUE(evictByDisk), VALUE(totalUsed_));
+        LOG_AUDIT("eviction", VALUE(actualEvict), VALUE(evictByCache), VALUE(evictByDisk), VALUE(totalUsed_));
     }
 
     while (actualEvict > 0 && !lru_.empty() && !exit_) {

--- a/src/overlaybd/cache/full_file_cache/cache_pool.cpp
+++ b/src/overlaybd/cache/full_file_cache/cache_pool.cpp
@@ -203,12 +203,20 @@ void FileCachePool::eviction() {
         evictByCache = totalUsed_ - waterMark_;
     }
 
-    auto actualEvict = static_cast<int64_t>(std::max(evictByCache, evictByDisk));
+    auto actualEvict = std::min(
+        static_cast<int64_t>(std::max(evictByCache, evictByDisk)),
+        totalUsed_
+    );
+
     if (actualEvict <= 0) {
         return;
     }
 
     isFull_ = true;
+
+    if (!lru_.empty() && !exit_) {
+        LOG_INFO("start eviction ", VALUE(actualEvict), VALUE(evictByCache), VALUE(evictByDisk), VALUE(totalUsed_));
+    }
 
     while (actualEvict > 0 && !lru_.empty() && !exit_) {
         auto fileIter = lru_.back();


### PR DESCRIPTION
**What this PR does / why we need it**:
## Problem

FileCachePool::eviction() computes the eviction target as:

    actualEvict = max(evictByCache, evictByDisk)

evictByDisk is derived from the whole-disk free space, which is not under the cache pool's control.  When other processes occupy the disk, evictByDisk can exceed totalUsed_ — the total bytes the pool actually owns.  After truncating every cache file to zero, actualEvict is still positive while the LRU holds only entries with openCount > 0 and size == 0.  These entries are moved to the LRU head on every iteration without reducing actualEvict, causing an infinite loop.

Concrete example:

  diskAvailInBytes_ = 150 MB  (configured minimum free space)
  disk free         =  50 MB  (occupied by other processes)
  evictByDisk       = 100 MB
  totalUsed_        =  30 MB  (all cache pool owns)

  actualEvict starts at 100 MB.  After clearing all 30 MB of cache,
  actualEvict = 70 MB > 0, but the LRU has no more evictable entries.

## Fix

Cap actualEvict to at most totalUsed_ before entering the loop:

    actualEvict = min(max(evictByCache, evictByDisk), totalUsed_)

The cache pool cannot free more than it owns.  With this bound, after all truncations complete, actualEvict ≤ 0 and the loop exits normally.

A diagnostic log line is added at loop entry to aid future analysis.

## Verification

Reproduced with a 200 MB ext4 loop device as the cache directory. 120 MB is pre-occupied by a noise file, leaving ~50 MB free against a 150 MB diskAvailInBytes_ threshold.  Three cache files are kept open (openCount > 0) to hold path-B entries in the LRU after truncation.  Without the fix eviction() never returns; with the fix it exits in O(n) iterations.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Please check the following list**:
- [ ]  Does the affected code have corresponding tests, e.g. unit test, E2E test?
- [ ]  Does this change require a documentation update?
- [ ]  Does this introduce breaking changes that would require an announcement or bumping the major version?
- [ ]  Do all new files have an appropriate license header?

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues directly to https://github.com/containerd/overlaybd/blob/main/MAINTAINERS. -->
