### PR TITLE
fix: pass node label value to OverlayBD_Alive metric render

### DIFF
--- a/src/exporter_handler.h
+++ b/src/exporter_handler.h
@@ -16,6 +16,8 @@
 
 #pragma once
 
+#include <unistd.h>
+
 #include <photon/common/conststr.h>
 #include <photon/common/estring.h>
 #include <photon/common/metric-meter/metrics.h>
@@ -50,8 +52,18 @@ struct ExposeRender : public photon::net::http::HTTPHandler {
     EXPOSE_PHOTON_METRICLIST(count, Metric::AddCounter);
     EXPOSE_PHOTON_METRICLIST(cache, Metric::ValueCounter);
 
+    std::string node_name;
+
     template <typename... Args>
-    ExposeRender(Args&&... args) {}
+    ExposeRender(Args&&... args) {
+        char hostname[256];
+        if (gethostname(hostname, sizeof(hostname)) == 0) {
+            hostname[sizeof(hostname) - 1] = '\0';
+            node_name = hostname;
+        } else {
+            node_name = "unknown";
+        }
+    }
 
     std::string render() {
         EXPOSE_TEMPLATE(alive, OverlayBD_Alive : gauge{node});
@@ -65,7 +77,7 @@ struct ExposeRender : public photon::net::http::HTTPHandler {
         ret.append("\n")
             .append(alive.type_str())
             .append("\n")
-            .append(alive.render(1))
+            .append(alive.render(1, node_name.c_str()))
             .append("\n\n");
         LOOP_APPEND_METRIC(ret, throughput);
         LOOP_APPEND_METRIC(ret, qps);


### PR DESCRIPTION
**What this PR does / why we need it**:
The OverlayBD_Alive metric produces malformed Prometheus exposition format output, causing Prometheus-compatible scrapers (e.g. vmagent) to fail parsing the /metrics endpoint. In src/exporter_handler.h, alive.render(1) is called without providing a string argument for the {node} label placeholder. The template renderer places the metric value and timestamp where the node label value should be, producing: 
OverlayBD_Alive{node="1.000000 1778265650342
instead of:
OverlayBD_Alive{node="<hostname>"} 1.000000 1778265650342

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes # This fix stores the machine hostname in ExposeRender and passes it to alive.render(1, node_name.c_str()), producing valid Prometheus output.

**Please check the following list**:
- [ ]  Does the affected code have corresponding tests, e.g. unit test, E2E test? No existing tests for the metrics exporter; this is a one-line bug fix to an existing render call.
- [ ]  Does this change require a documentation update? No.
- [ ]  Does this introduce breaking changes that would require an announcement or bumping the major version? No. The metric was previously unparseable; this makes it valid.
- [ ]  Do all new files have an appropriate license header? No new files; only an existing file was modified.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues directly to https://github.com/containerd/overlaybd/blob/main/MAINTAINERS. -->
