### PR TITLE
ci: pin third-party GitHub Actions to commit SHAs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,9 +32,9 @@ jobs:
       with:
         submodules: true
     - name: Set up QEMU
-      uses: docker/setup-qemu-action@v3
+      uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3
     - name: Setup buildx instance
-      uses: docker/setup-buildx-action@v3
+      uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
     - name: Build
       shell: bash
       run: |
@@ -113,7 +113,7 @@ jobs:
         shell: bash
         run: ls -l releases*/
       - name: Create Release
-        uses: "marvinpinto/action-automatic-releases@latest"
+        uses: "marvinpinto/action-automatic-releases@d68defdd11f9dcc7f52f35c1b7c236ee7513bcc1" # latest
         with:
           repo_token: "${{ secrets.GITHUB_TOKEN }}"
           automatic_release_tag: "latest"
@@ -134,7 +134,7 @@ jobs:
         shell: bash
         run: ls -l releases*/
       - name: Create Release
-        uses: "marvinpinto/action-automatic-releases@latest"
+        uses: "marvinpinto/action-automatic-releases@d68defdd11f9dcc7f52f35c1b7c236ee7513bcc1" # latest
         with:
           repo_token: "${{ secrets.GITHUB_TOKEN }}"
           prerelease: false


### PR DESCRIPTION
The release workflow pulls three external actions by mutable refs: two Docker setup actions on `@v3`, plus `marvinpinto/action-automatic-releases@latest` used twice. `@latest` in particular is dangerous in a release job, because it grabs whatever the upstream maintainer most recently tagged and runs it with the workflow's write-scoped token, no review step in between.

This is the same weakness exploited in CVE-2025-30066, where tj-actions/changed-files tags were force-pushed to malicious commits and exfiltrated secrets from many CI pipelines. Resolving each action to a fixed commit SHA means only the reviewed code runs, even if the upstream tag later moves.

I pinned all four uses in release.yml and left the original ref in a trailing comment (for example `# v3`, `# latest`) so the intended track is still obvious and Dependabot can keep proposing bumps. GitHub's own actions/* were not changed. This also helps the OpenSSF Scorecard Pinned-Dependencies check pass.