### PR TITLE
remove build release for 'centos 7'

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,11 +14,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        images: [ubuntu_18.04, ubuntu_20.04, ubuntu_22.04, ubuntu_24.04, centos_7, centos_8, mcr.microsoft.com/cbl-mariner/base/core_2.0, mcr.microsoft.com/azurelinux/base/core_3.0]
+        images: [ubuntu_18.04, ubuntu_20.04, ubuntu_22.04, ubuntu_24.04, centos_8, mcr.microsoft.com/cbl-mariner/base/core_2.0, mcr.microsoft.com/azurelinux/base/core_3.0]
         platforms: [linux/amd64, linux/arm64]
-        exclude:
-          - images: centos_7
-            platforms: linux/arm64
     steps:
     - name: Set Release Version
       if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')


### PR DESCRIPTION
**What this PR does / why we need it**:

CentOS 7 has been without official support for many years and frequently fails during release builds. This change removes the CentOS 7 build and discontinues support for it.

**Please check the following list**:
- [x]  Does the affected code have corresponding tests, e.g. unit test, E2E test?
- [ ]  Does this change require a documentation update?
- [ ]  Does this introduce breaking changes that would require an announcement or bumping the major version?
- [ ]  Do all new files have an appropriate license header?

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues directly to https://github.com/containerd/overlaybd/blob/main/MAINTAINERS. -->
