### PR TITLE
ci: add Dependabot config to auto-update dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,21 @@
+# Keep dependencies up to date automatically.
+# https://docs.github.com/code-security/dependabot/dependabot-version-updates
+version: 2
+updates:
+  # GitHub Actions used by CI/release workflows
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+
+  # Git submodules (vendored C/C++ dependencies)
+  - package-ecosystem: "gitsubmodule"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+
+  # Base image for the release build container
+  - package-ecosystem: "docker"
+    directory: "/.github/workflows/release"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
## What

Adds `.github/dependabot.yml` to enable automated **weekly** dependency updates via Dependabot for:

- **GitHub Actions** (`/`) — keeps CI/release workflow actions current (incl. security patches).
- **Git submodules** (`/`) — the vendored C/C++ dependencies tracked as submodules.
- **Docker** (`/.github/workflows/release`) — base image for the release build container.

## Why

Dependencies in this repo are not currently tracked for updates, so security fixes in actions, submodules, and base images can go unnoticed. Dependabot will open PRs as updates become available for maintainers to review and merge.

Notes:
- Schedule is `weekly` to balance freshness vs. PR noise — happy to switch to `monthly` or add grouping if preferred.
- Submodule update PRs bump to the latest upstream commit and should be reviewed carefully.

Signed-off-by included (DCO).