### PR TITLE
fix: fix ubuntu 26 release failure

### DIFF
--- a/.github/workflows/project-checks.yml
+++ b/.github/workflows/project-checks.yml
@@ -19,7 +19,7 @@ jobs:
     timeout-minutes: 5
 
     steps:
-      - uses: actions/setup-go@v3
+      - uses: actions/setup-go@v6
         with:
           go-version: 1.19
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,7 +29,7 @@ jobs:
       with:
         submodules: true
     - name: Set up QEMU
-      uses: docker/setup-qemu-action@v3
+      uses: docker/setup-qemu-action@v4
     - name: Setup buildx instance
       uses: docker/setup-buildx-action@v4
     - name: Build
@@ -95,7 +95,7 @@ jobs:
         name="releases-${image//\//_}-${platform/\//_}"
         echo "name=${name}" >> "$GITHUB_OUTPUT"
     - name: Upload
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: ${{ steps.upload_name.outputs.name }}
         path: releases/overlaybd-*.*

--- a/.github/workflows/release/build.sh
+++ b/.github/workflows/release/build.sh
@@ -83,8 +83,28 @@ elif [[ ${OS} =~ "mariner" ]]; then
     PACKAGE_RELEASE="-DPACKAGE_RELEASE=${RELEASE_NO}.${DISTRO}"
 elif [[ ${OS} =~ "azurelinux" ]]; then
     tdnf update -y
-    tdnf install -y libaio-devel libcurl-devel openssl-devel libnl3-devel e2fsprogs-devel glibc-devel libzstd-devel binutils ca-certificates-microsoft build-essential
-    tdnf install -y rpm-build make git wget sudo tar gcc gcc-c++ autoconf automake libtool
+    if [[ ${OS} =~ "azurelinux:4" ]]; then
+        # Azure Linux 4.0 removed the `ca-certificates-microsoft` and
+        # `build-essential` packages that AL3 ships, and no longer pulls
+        # zlib-devel/pkg-config in transitively. Install the equivalent set
+        # explicitly. (gcc/gcc-c++/make/binutils/glibc-devel/autoconf/
+        # automake/libtool are already installed on the next line, which is
+        # everything `build-essential` provided.)
+        tdnf install -y libaio-devel libcurl-devel openssl-devel libnl3-devel e2fsprogs-devel glibc-devel libzstd-devel binutils ca-certificates zlib-devel
+        tdnf install -y rpm-build make git wget sudo tar gcc gcc-c++ autoconf automake libtool pkg-config
+
+        # Azure Linux 4's rpmbuild runs check-rpaths which rejects the
+        # /opt/overlaybd/lib RPATH baked into our binaries (they link against
+        # the bundled libext2fs installed there). Bit 0x0002 = "rpath contains
+        # a directory not in the standard set" -- the exact check we hit. Only
+        # bypass this single check; the produced binaries are byte-identical
+        # to what other targets ship.
+        export QA_RPATHS=0x0002
+    else
+        # Azure Linux 3.0 (and earlier) -- unchanged from the original recipe.
+        tdnf install -y libaio-devel libcurl-devel openssl-devel libnl3-devel e2fsprogs-devel glibc-devel libzstd-devel binutils ca-certificates-microsoft build-essential
+        tdnf install -y rpm-build make git wget sudo tar gcc gcc-c++ autoconf automake libtool
+    fi
 
     DISTRO=${OS/:/.}
     PACKAGE_RELEASE="-DPACKAGE_RELEASE=${RELEASE_NO}.${DISTRO}"

--- a/CMake/Finde2fs.cmake
+++ b/CMake/Finde2fs.cmake
@@ -14,10 +14,22 @@ if(NOT ORIGIN_EXT2FS)
         set(E2FS_RESIZE_DIR ${e2fsprogs_SOURCE_DIR}/build/resize CACHE STRING "path to e2fsprogs resize build dir")
         set(E2FS_INSTALL_LIB_DIR ${LIBEXT2FS_INSTALL_DIR}/lib CACHE STRING "path to e2fsprogs install-libs output")
 
+        # Force the e2fsprogs autotools build to use C11. GCC 15 (Ubuntu 26.04,
+        # Azure Linux 4.0) defaults to C23, under which `typedef int bool;` in
+        # lib/ext2fs/tdb.c is illegal because `bool` is now a keyword. The
+        # upstream build.sh hardcodes `CFLAGS="-fPIC -O3"` on the configure
+        # line, so setting CFLAGS via the environment is ignored -- we patch
+        # build.sh in place instead. The `grep -q` guard fails the build loudly
+        # if the pinned e2fsprogs commit is ever bumped and this literal string
+        # no longer matches, so we don't silently regress. `-std=gnu11` is
+        # supported by every compiler used across the release matrix (GCC 7+).
         add_custom_command(
             OUTPUT ${LIBEXT2FS_INSTALL_DIR}/lib
             WORKING_DIRECTORY ${e2fsprogs_SOURCE_DIR}
-            COMMAND chmod 755 build.sh && ./build.sh
+            COMMAND chmod 755 build.sh
+            COMMAND grep -q 'CFLAGS="-fPIC -O3"' build.sh
+            COMMAND sed -i 's|CFLAGS="-fPIC -O3"|CFLAGS="-fPIC -O3 -std=gnu11"|' build.sh
+            COMMAND ./build.sh
         )
         add_custom_target(libext2fs_build DEPENDS ${LIBEXT2FS_INSTALL_DIR}/lib)
     endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,6 +23,17 @@ set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_CURRENT_SOURCE_DIR}/CMake")
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fpic -Wall -Werror=sign-compare")
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fpic -Wall -Werror=sign-compare -DOVERLAYBD_VER=${OBD_VER}")
 
+<<<<<<< HEAD
+# GCC 13+ (default on Ubuntu 26.04 and Azure Linux 4.0) no longer transitively
+=======
+# GCC 13+ (default on Azure Linux 4.0 with GCC 15) no longer transitively
+>>>>>>> 0f35a8b (update build defs)
+# includes <cstdint> from other standard headers. Force-include it for every
+# C++ translation unit so that fixed-width integer types (uint64_t, etc.) used
+# in third-party headers (e.g. photon's fs/path.h at the pinned commit) resolve
+# without needing to upgrade those pins. C sources (e.g. OCF) are unaffected.
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -include cstdint")
+
 if ((CMAKE_SYSTEM_PROCESSOR STREQUAL aarch64) OR (CMAKE_SYSTEM_PROCESSOR STREQUAL arm64))
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -march=armv8-a+crc -fsigned-char -fno-stack-protector -fomit-frame-pointer")
 endif ()
@@ -56,7 +67,9 @@ if(BUILD_STREAM_CONVERTOR)
         FetchContent_Declare(
             yaml-cpp
             GIT_REPOSITORY https://github.com/jbeder/yaml-cpp.git
-            GIT_TAG 0.8.0
+            # 0.9.0 includes the missing <cstdint> include (PR #1310) required
+            # to build with GCC 13+, e.g. on Ubuntu 26.04 and Azure Linux 4.0.
+            GIT_TAG yaml-cpp-0.9.0
         )
         FetchContent_MakeAvailable(yaml-cpp)
     endif()


### PR DESCRIPTION
The release workflow currently fails with ubuntu 26 build. This PR aims to fix it.