### PR TITLE
Validate LSMT and ZFile index sizes

### DIFF
--- a/src/overlaybd/lsmt/file.cpp
+++ b/src/overlaybd/lsmt/file.cpp
@@ -1367,6 +1367,7 @@ static SegmentMapping *do_load_index(IFile *file, HeaderTrailer *pheader_trailer
         LOG_ERRNO_RETURN(0, nullptr, "failed to stat file.");
     assert(trailer || pht->is_sparse_rw() == false);
     uint64_t index_bytes;
+    uint64_t trailer_offset = 0;
     if (trailer) {
         if (!pht->is_data_file())
             LOG_ERROR_RETURN(0, nullptr, "uncognized file type");
@@ -1374,14 +1375,8 @@ static SegmentMapping *do_load_index(IFile *file, HeaderTrailer *pheader_trailer
         if (pht == nullptr) {
             return nullptr;
         }
-        auto trailer_offset = stat.st_size - HeaderTrailer::SPACE;
+        trailer_offset = stat.st_size - HeaderTrailer::SPACE;
         LOG_DEBUG("index_size: `, trailer offset: `", pht->index_size + 0, trailer_offset);
-        if (pht->index_size > MAX_LSMT_INDEX_SIZE)
-            LOG_ERROR_RETURN(0, nullptr, "LSMT index size ` exceeds maximum `",
-                             pht->index_size + 0, MAX_LSMT_INDEX_SIZE);
-        index_bytes = pht->index_size * sizeof(SegmentMapping);
-        if (index_bytes > trailer_offset - pht->index_offset)
-            LOG_ERROR_RETURN(0, nullptr, "invalid index bytes or size");
 
     } else {
         if (!pht->is_index_file() || pht->is_sealed())
@@ -1390,10 +1385,18 @@ static SegmentMapping *do_load_index(IFile *file, HeaderTrailer *pheader_trailer
             LOG_ERROR_RETURN(0, nullptr, "index offset wrong");
         index_bytes = stat.st_size - HeaderTrailer::SPACE;
         pht->index_size = index_bytes / sizeof(SegmentMapping);
-        if (pht->index_size > MAX_LSMT_INDEX_SIZE)
-            LOG_ERROR_RETURN(0, nullptr, "LSMT index size ` exceeds maximum `",
-                             pht->index_size + 0, MAX_LSMT_INDEX_SIZE);
     }
+
+    if (pht->index_size > MAX_LSMT_INDEX_SIZE)
+        LOG_ERROR_RETURN(0, nullptr, "LSMT index size ` exceeds maximum `",
+                         pht->index_size + 0, MAX_LSMT_INDEX_SIZE);
+
+    if (trailer) {
+    index_bytes = pht->index_size * sizeof(SegmentMapping);
+    if (index_bytes > trailer_offset - pht->index_offset)
+        LOG_ERROR_RETURN(0, nullptr, "invalid index bytes or size");
+    }
+
     SegmentMapping *ibuf = nullptr;
     posix_memalign((void **)&ibuf, ALIGNMENT4K, pht->index_size * sizeof(*ibuf));
     ret = file->pread(ibuf, index_bytes, pht->index_offset);

--- a/src/overlaybd/lsmt/file.cpp
+++ b/src/overlaybd/lsmt/file.cpp
@@ -45,6 +45,7 @@ using namespace photon::fs;
 typedef atomic<uint64_t> atomic_uint64_t;
 
 namespace LSMT {
+static const uint64_t MAX_LSMT_INDEX_SIZE = 1000000;
 LogBuffer &operator<<(LogBuffer &log, Segment s) {
     return log.printf("Segment[", s.offset + 0, ',', s.length + 0, ']');
 }
@@ -1376,6 +1377,9 @@ static SegmentMapping *do_load_index(IFile *file, HeaderTrailer *pheader_trailer
         }
         auto trailer_offset = stat.st_size - HeaderTrailer::SPACE;
         LOG_DEBUG("index_size: `, trailer offset: `", pht->index_size + 0, trailer_offset);
+        if (pht->index_size > MAX_LSMT_INDEX_SIZE)
+            LOG_ERROR_RETURN(0, nullptr, "LSMT index size ` exceeds maximum `",
+                                    pht->index_size + 0, MAX_LSMT_INDEX_SIZE);
         index_bytes = pht->index_size * sizeof(SegmentMapping);
         if (index_bytes > trailer_offset - pht->index_offset)
             LOG_ERROR_RETURN(0, nullptr, "invalid index bytes or size");
@@ -1387,6 +1391,9 @@ static SegmentMapping *do_load_index(IFile *file, HeaderTrailer *pheader_trailer
             LOG_ERROR_RETURN(0, nullptr, "index offset wrong");
         index_bytes = stat.st_size - HeaderTrailer::SPACE;
         pht->index_size = index_bytes / sizeof(SegmentMapping);
+        if (pht->index_size > MAX_LSMT_INDEX_SIZE)
+            LOG_ERROR_RETURN(0, nullptr, "LSMT index size ` exceeds maximum `",
+                                    pht->index_size + 0, MAX_LSMT_INDEX_SIZE);
     }
 
     SegmentMapping *ibuf = nullptr;

--- a/src/overlaybd/lsmt/file.cpp
+++ b/src/overlaybd/lsmt/file.cpp
@@ -1029,6 +1029,9 @@ public:
     virtual int flatten(IFile *as) override {
 
         unique_ptr<IComboIndex> pmi((IComboIndex*)(m_index->make_read_only_index()));
+        if (!pmi)
+            LOG_ERROR_RETURN(0, -1, "failed to make read only index.");
+
         CommitArgs args(as);
         atomic_uint64_t _no_use_var(0);
         CompactOptions opts(&m_files, (SegmentMapping*)(pmi->buffer()), pmi->size(), m_vsize, &args);
@@ -1350,6 +1353,10 @@ static HeaderTrailer *verify_ht(IFile *file, char *buf, bool is_trailer, ssize_t
         LOG_ERROR_RETURN(0, nullptr,
                          "trailer magic, trailer type, "
                          "file type or sealedness doesn't match");
+
+    if (pht->index_size > MAX_LSMT_RO_INDEX_SIZE)
+        LOG_ERROR_RETURN(0, nullptr, "LSMT RO index size ` exceeds maximum `",
+                         pht->index_size + 0, MAX_LSMT_RO_INDEX_SIZE);
     return pht;
 }
 
@@ -1367,7 +1374,6 @@ static SegmentMapping *do_load_index(IFile *file, HeaderTrailer *pheader_trailer
         LOG_ERRNO_RETURN(0, nullptr, "failed to stat file.");
     assert(trailer || pht->is_sparse_rw() == false);
     uint64_t index_bytes;
-    uint64_t trailer_offset = 0;
     if (trailer) {
         if (!pht->is_data_file())
             LOG_ERROR_RETURN(0, nullptr, "uncognized file type");
@@ -1375,8 +1381,11 @@ static SegmentMapping *do_load_index(IFile *file, HeaderTrailer *pheader_trailer
         if (pht == nullptr) {
             return nullptr;
         }
-        trailer_offset = stat.st_size - HeaderTrailer::SPACE;
+        auto trailer_offset = stat.st_size - HeaderTrailer::SPACE;
         LOG_DEBUG("index_size: `, trailer offset: `", pht->index_size + 0, trailer_offset);
+        index_bytes = pht->index_size * sizeof(SegmentMapping);
+        if (index_bytes > trailer_offset - pht->index_offset)
+            LOG_ERROR_RETURN(0, nullptr, "invalid index bytes or size");
 
     } else {
         if (!pht->is_index_file() || pht->is_sealed())
@@ -1385,16 +1394,10 @@ static SegmentMapping *do_load_index(IFile *file, HeaderTrailer *pheader_trailer
             LOG_ERROR_RETURN(0, nullptr, "index offset wrong");
         index_bytes = stat.st_size - HeaderTrailer::SPACE;
         pht->index_size = index_bytes / sizeof(SegmentMapping);
-    }
 
-    if (pht->index_size > MAX_LSMT_INDEX_SIZE)
-        LOG_ERROR_RETURN(0, nullptr, "LSMT index size ` exceeds maximum `",
-                         pht->index_size + 0, MAX_LSMT_INDEX_SIZE);
-
-    if (trailer) {
-        index_bytes = pht->index_size * sizeof(SegmentMapping);
-        if (index_bytes > trailer_offset - pht->index_offset)
-            LOG_ERROR_RETURN(0, nullptr, "invalid index bytes or size");
+        if (pht->index_size > MAX_LSMT_INDEX_SIZE)
+            LOG_ERROR_RETURN(0, nullptr, "LSMT RW index size ` exceeds maximum `",
+                             pht->index_size + 0, MAX_LSMT_INDEX_SIZE);
     }
 
     SegmentMapping *ibuf = nullptr;

--- a/src/overlaybd/lsmt/file.cpp
+++ b/src/overlaybd/lsmt/file.cpp
@@ -1376,6 +1376,9 @@ static SegmentMapping *do_load_index(IFile *file, HeaderTrailer *pheader_trailer
         }
         auto trailer_offset = stat.st_size - HeaderTrailer::SPACE;
         LOG_DEBUG("index_size: `, trailer offset: `", pht->index_size + 0, trailer_offset);
+        if (pht->index_size > MAX_LSMT_INDEX_SIZE)
+            LOG_ERROR_RETURN(0, nullptr, "LSMT index size ` exceeds maximum `",
+                             pht->index_size + 0, MAX_LSMT_INDEX_SIZE);
         index_bytes = pht->index_size * sizeof(SegmentMapping);
         if (index_bytes > trailer_offset - pht->index_offset)
             LOG_ERROR_RETURN(0, nullptr, "invalid index bytes or size");
@@ -1387,12 +1390,10 @@ static SegmentMapping *do_load_index(IFile *file, HeaderTrailer *pheader_trailer
             LOG_ERROR_RETURN(0, nullptr, "index offset wrong");
         index_bytes = stat.st_size - HeaderTrailer::SPACE;
         pht->index_size = index_bytes / sizeof(SegmentMapping);
+        if (pht->index_size > MAX_LSMT_INDEX_SIZE)
+            LOG_ERROR_RETURN(0, nullptr, "LSMT index size ` exceeds maximum `",
+                             pht->index_size + 0, MAX_LSMT_INDEX_SIZE);
     }
-
-    if (pht->index_size > MAX_LSMT_INDEX_SIZE)
-        LOG_ERROR_RETURN(0, nullptr, "LSMT index size ` exceeds maximum `",
-                         pht->index_size + 0, MAX_LSMT_INDEX_SIZE);
-
     SegmentMapping *ibuf = nullptr;
     posix_memalign((void **)&ibuf, ALIGNMENT4K, pht->index_size * sizeof(*ibuf));
     ret = file->pread(ibuf, index_bytes, pht->index_offset);

--- a/src/overlaybd/lsmt/file.cpp
+++ b/src/overlaybd/lsmt/file.cpp
@@ -45,7 +45,6 @@ using namespace photon::fs;
 typedef atomic<uint64_t> atomic_uint64_t;
 
 namespace LSMT {
-static const uint64_t MAX_LSMT_INDEX_SIZE = 1000000;
 LogBuffer &operator<<(LogBuffer &log, Segment s) {
     return log.printf("Segment[", s.offset + 0, ',', s.length + 0, ']');
 }
@@ -1377,9 +1376,6 @@ static SegmentMapping *do_load_index(IFile *file, HeaderTrailer *pheader_trailer
         }
         auto trailer_offset = stat.st_size - HeaderTrailer::SPACE;
         LOG_DEBUG("index_size: `, trailer offset: `", pht->index_size + 0, trailer_offset);
-        if (pht->index_size > MAX_LSMT_INDEX_SIZE)
-            LOG_ERROR_RETURN(0, nullptr, "LSMT index size ` exceeds maximum `",
-                                    pht->index_size + 0, MAX_LSMT_INDEX_SIZE);
         index_bytes = pht->index_size * sizeof(SegmentMapping);
         if (index_bytes > trailer_offset - pht->index_offset)
             LOG_ERROR_RETURN(0, nullptr, "invalid index bytes or size");
@@ -1391,10 +1387,11 @@ static SegmentMapping *do_load_index(IFile *file, HeaderTrailer *pheader_trailer
             LOG_ERROR_RETURN(0, nullptr, "index offset wrong");
         index_bytes = stat.st_size - HeaderTrailer::SPACE;
         pht->index_size = index_bytes / sizeof(SegmentMapping);
-        if (pht->index_size > MAX_LSMT_INDEX_SIZE)
-            LOG_ERROR_RETURN(0, nullptr, "LSMT index size ` exceeds maximum `",
-                                    pht->index_size + 0, MAX_LSMT_INDEX_SIZE);
     }
+
+    if (pht->index_size > MAX_LSMT_INDEX_SIZE)
+        LOG_ERROR_RETURN(0, nullptr, "LSMT index size ` exceeds maximum `",
+                         pht->index_size + 0, MAX_LSMT_INDEX_SIZE);
 
     SegmentMapping *ibuf = nullptr;
     posix_memalign((void **)&ibuf, ALIGNMENT4K, pht->index_size * sizeof(*ibuf));

--- a/src/overlaybd/lsmt/file.cpp
+++ b/src/overlaybd/lsmt/file.cpp
@@ -1392,9 +1392,9 @@ static SegmentMapping *do_load_index(IFile *file, HeaderTrailer *pheader_trailer
                          pht->index_size + 0, MAX_LSMT_INDEX_SIZE);
 
     if (trailer) {
-    index_bytes = pht->index_size * sizeof(SegmentMapping);
-    if (index_bytes > trailer_offset - pht->index_offset)
-        LOG_ERROR_RETURN(0, nullptr, "invalid index bytes or size");
+        index_bytes = pht->index_size * sizeof(SegmentMapping);
+        if (index_bytes > trailer_offset - pht->index_offset)
+            LOG_ERROR_RETURN(0, nullptr, "invalid index bytes or size");
     }
 
     SegmentMapping *ibuf = nullptr;

--- a/src/overlaybd/lsmt/index.cpp
+++ b/src/overlaybd/lsmt/index.cpp
@@ -312,7 +312,8 @@ public:
     }
 
     int increase_tag(int delta) override {
-        LOG_DEBUG("index tag add `", delta);
+
+        ("index tag add `", delta);
         auto array = ptr_array((SegmentMapping *)this->buffer(), this->size());
         for (auto &m : array)
             m.tag += delta;
@@ -622,9 +623,10 @@ public:
     UNIMPLEMENTED(int commit_index0() override);
 };
 
-static void merge_indexes(uint8_t level, vector<SegmentMapping> &mapping, const Index **pindexes,
+static bool merge_indexes(uint8_t level, vector<SegmentMapping> &mapping, const Index **pindexes,
                           std::size_t n, uint64_t begin, uint64_t end, bool change_tag = true,
-                          size_t max_level = 0);
+                          size_t max_level = 0,
+                          size_t max_index_size = MAX_LSMT_INDEX_SIZE);
 
 class ComboIndex : public Index0 {
 public:
@@ -740,7 +742,8 @@ public:
     virtual Index *rebuild_backing_index(Index *highlevel_idx, size_t max_level) {
         vector<SegmentMapping> mappings;
         const Index *indexes[2] = {highlevel_idx, const_cast<Index *>(m_backing_index)};
-        merge_indexes(0, mappings, indexes, 2, 0, UINT64_MAX, false, max_level);
+        if (!merge_indexes(0, mappings, indexes, 2, 0, UINT64_MAX, false, max_level))
+            return nullptr;
         return new Index(std::move(mappings));
     }
 
@@ -753,7 +756,10 @@ public:
             return ro_idx0;
         }
         const Index *indexes[2] = {ro_idx0, const_cast<Index *>(m_backing_index)};
-        merge_indexes(0, mappings, indexes, 2, 0, UINT64_MAX, false, 2);
+        if (!merge_indexes(0, mappings, indexes, 2, 0, UINT64_MAX, false, 2)) {
+            delete ro_idx0;
+            return nullptr;
+        }
         delete ro_idx0;
         return new Index(std::move(mappings));
     }
@@ -839,35 +845,41 @@ IMemoryIndex *create_level_index(const SegmentMapping *pmappings, size_t n, uint
     return (ok1 && ok2) ? new LevelIndex(pmappings, n, copy_mode) : nullptr;
 }
 
-static void merge_indexes(uint8_t level, vector<SegmentMapping> &mapping, const Index **pindexes,
+static bool merge_indexes(uint8_t level, vector<SegmentMapping> &mapping, const Index **pindexes,
                           size_t n, uint64_t begin, uint64_t end, bool change_tag,
-                          size_t max_level) {
+                          size_t max_level, size_t max_index_size) {
 
     if (pindexes == nullptr)
-        return;
+        return true;
     if (change_tag) {
         if (n == 0)
-            return;
+            return true;
     } else {
         if (max_level == 0)
-            return;
+            return true;
     }
     if (begin >= end)
-        return;
+        return true;
 
     auto begin0 = begin;
     auto size0 = mapping.size();
     auto pi0 = pindexes[0];
     for (auto it = pi0->lower_bound(begin); it != pi0->end() && it->offset < end; ++it) {
         if (it->offset > begin) {
-            if (change_tag)
-                merge_indexes(level + 1, mapping, pindexes + 1, n - 1, begin, it->offset);
-            else {
+            if (change_tag) {
+                if (!merge_indexes(level + 1, mapping, pindexes + 1, n - 1, begin, it->offset,
+                                true, max_level, max_index_size))
+                    return false;
+            } else {
                 int k = (n <= 1 ? 0 : 1);
-                merge_indexes(level + 1, mapping, pindexes + k, 0, begin, it->offset, false,
-                              max_level - 1);
+                if (!merge_indexes(level + 1, mapping, pindexes + k, 0, begin, it->offset, false,
+                                max_level - 1, max_index_size))
+                    return false;
             }
         }
+        if (mapping.size() >= max_index_size)
+            LOG_ERROR_RETURN(0, false, "Merged LSMT index size ` exceeds maximum `",
+                            mapping.size() + 1, max_index_size);
 
         mapping.push_back(*it);
         if (change_tag) {
@@ -876,11 +888,15 @@ static void merge_indexes(uint8_t level, vector<SegmentMapping> &mapping, const 
         begin = it->end();
     }
     if (begin < end) {
-        if (change_tag)
-            merge_indexes(level + 1, mapping, pindexes + 1, n - 1, begin, end);
-        else {
+        if (change_tag) {
+            if (!merge_indexes(level + 1, mapping, pindexes + 1, n - 1, begin, end,
+                            true, max_level, max_index_size))
+                return false;
+        } else {
             int k = (n <= 1 ? 0 : 1);
-            merge_indexes(level + 1, mapping, pindexes + k, 0, begin, end, false, max_level - 1);
+            if (!merge_indexes(level + 1, mapping, pindexes + k, 0, begin, end, false,
+                            max_level - 1, max_index_size))
+                return false;
         }
     }
     if (mapping.size() > size0) {
@@ -889,6 +905,8 @@ static void merge_indexes(uint8_t level, vector<SegmentMapping> &mapping, const 
         if (mapping.back().end() > end)
             mapping.back().backward_end_to(end);
     }
+
+    return true;
 }
 
 IComboIndex *create_combo_index(IMemoryIndex0 *index0, const IMemoryIndex *index,
@@ -952,12 +970,8 @@ IMemoryIndex *merge_memory_indexes(const IMemoryIndex **pindexes, size_t n) {
     vector<SegmentMapping> mapping;
     auto pi = (const Index **)pindexes;
     mapping.reserve(pi[0]->size());
-    merge_indexes(0, mapping, pi, n, 0, UINT64_MAX);
-
-    if (mapping.size() > MAX_LSMT_INDEX_SIZE)
-        LOG_ERROR_RETURN(0, nullptr,
-                         "Merged LSMT index size ` exceeds maximum `",
-                         mapping.size(), MAX_LSMT_INDEX_SIZE);
+    if (!merge_indexes(0, mapping, pi, n, 0, UINT64_MAX))
+        return nullptr;
 
     if (pindexes[0]->vsize() < static_cast<uint64_t>(UINT32_MAX) * ALIGNMENT
         && mapping.size() < NODES_PER_LEVEL_32[MAX_LEVEL_32-1]) {

--- a/src/overlaybd/lsmt/index.cpp
+++ b/src/overlaybd/lsmt/index.cpp
@@ -954,6 +954,11 @@ IMemoryIndex *merge_memory_indexes(const IMemoryIndex **pindexes, size_t n) {
     mapping.reserve(pi[0]->size());
     merge_indexes(0, mapping, pi, n, 0, UINT64_MAX);
 
+    if (mapping.size() > MAX_LSMT_INDEX_SIZE)
+        LOG_ERROR_RETURN(0, nullptr,
+                         "Merged LSMT index size ` exceeds maximum `",
+                         mapping.size(), MAX_LSMT_INDEX_SIZE);
+
     if (pindexes[0]->vsize() < static_cast<uint64_t>(UINT32_MAX) * ALIGNMENT
         && mapping.size() < NODES_PER_LEVEL_32[MAX_LEVEL_32-1]) {
         return new_index_with_lineriazed_bptree<uint32_t>(std::move(mapping), pindexes[0]->vsize());

--- a/src/overlaybd/lsmt/index.cpp
+++ b/src/overlaybd/lsmt/index.cpp
@@ -312,8 +312,7 @@ public:
     }
 
     int increase_tag(int delta) override {
-
-        ("index tag add `", delta);
+        LOG_DEBUG("index tag add `", delta);
         auto array = ptr_array((SegmentMapping *)this->buffer(), this->size());
         for (auto &m : array)
             m.tag += delta;

--- a/src/overlaybd/lsmt/index.h
+++ b/src/overlaybd/lsmt/index.h
@@ -29,7 +29,8 @@ IMemoryIndex -> IMemoryIndex0 -> IComboIndex -> Index0 ( set<SegmentMap> ) -> Co
 #include <sys/types.h>
 
 namespace LSMT {
-static const uint64_t MAX_LSMT_INDEX_SIZE = 1000000;
+static const uint64_t MAX_LSMT_RO_INDEX_SIZE = 1000000;
+static const uint64_t MAX_LSMT_INDEX_SIZE = 128000000;
 struct Segment {          
     uint64_t offset : 50;
     uint32_t length : 14;

--- a/src/overlaybd/lsmt/index.h
+++ b/src/overlaybd/lsmt/index.h
@@ -29,6 +29,7 @@ IMemoryIndex -> IMemoryIndex0 -> IComboIndex -> Index0 ( set<SegmentMap> ) -> Co
 #include <sys/types.h>
 
 namespace LSMT {
+static const uint64_t MAX_LSMT_INDEX_SIZE = 1000000;
 struct Segment {          
     uint64_t offset : 50;
     uint32_t length : 14;

--- a/src/overlaybd/lsmt/test/test.cpp
+++ b/src/overlaybd/lsmt/test/test.cpp
@@ -72,7 +72,7 @@ TEST_F(FileTest, reject_oversized_index) {
     ASSERT_EQ(write_header_trailer(file, true, true, true, 0, 0, info),
               (int)HeaderTrailer::SPACE);
 
-    const uint64_t index_size = MAX_LSMT_INDEX_SIZE + 1;
+    const uint64_t index_size = MAX_LSMT_RO_INDEX_SIZE + 1;
     const uint64_t index_offset = HeaderTrailer::SPACE;
     const uint64_t trailer_offset =
         index_offset + index_size * sizeof(SegmentMapping);
@@ -84,6 +84,29 @@ TEST_F(FileTest, reject_oversized_index) {
     EXPECT_EQ(LSMT::open_file_ro(file), nullptr);
     delete file;
     lfs->unlink(filename);
+}
+
+TEST_F(FileTest, reject_oversized_rw_index) {
+    auto rw = create_file_rw();
+    ASSERT_NE(rw, nullptr);
+    delete rw;
+
+    auto fdata = lfs->open(data_name.back().c_str(), O_RDWR, S_IRWXU);
+    auto findex = lfs->open(idx_name.back().c_str(), O_RDWR, S_IRWXU);
+    ASSERT_NE(fdata, nullptr);
+    ASSERT_NE(findex, nullptr);
+
+    const uint64_t index_file_size =
+        HeaderTrailer::SPACE +
+        (MAX_LSMT_INDEX_SIZE + 1) * sizeof(SegmentMapping);
+    ASSERT_EQ(findex->ftruncate(index_file_size), 0);
+
+    auto reopened = LSMT::open_file_rw(fdata, findex, false);
+    EXPECT_EQ(reopened, nullptr);
+
+    delete reopened;
+    delete fdata;
+    delete findex;
 }
 
 void lookup_test(IMemoryIndex &idx);
@@ -292,24 +315,17 @@ inline void test_merge_combo(const IMemoryIndex *indexes[], size_t ni, // num of
 }
 
 TEST(Index, reject_oversized_merge) {
-    const size_t per_index_size = MAX_LSMT_INDEX_SIZE / 2 + 1;
-    vector<SegmentMapping> mapping0;
-    vector<SegmentMapping> mapping1;
-    mapping0.reserve(per_index_size);
-    mapping1.reserve(per_index_size);
+    SegmentMapping mapping0[] = {{0, 1, 0}, {2, 1, 2}};
+    SegmentMapping mapping1[] = {{1, 1, 1}, {3, 1, 3}};
 
-    for (size_t i = 0; i < per_index_size; ++i) {
-        mapping0.emplace_back(i * 2, 1, i * 2);
-        mapping1.emplace_back(i * 2 + 1, 1, i * 2 + 1);
-    }
+    Index index0(mapping0, LEN(mapping0), false);
+    Index index1(mapping1, LEN(mapping1), false);
+    const Index *indexes[] = {&index0, &index1};
 
-    Index index0(mapping0.data(), mapping0.size(), false);
-    Index index1(mapping1.data(), mapping1.size(), false);
-    const IMemoryIndex *indexes[] = {&index0, &index1};
-
-    auto merged = merge_memory_indexes(indexes, LEN(indexes));
-    EXPECT_EQ(merged, nullptr);
-    delete merged;
+    vector<SegmentMapping> merged;
+    EXPECT_FALSE(merge_indexes(0, merged, indexes, LEN(indexes), 0, UINT64_MAX,
+                               true, 0, 3));
+    EXPECT_EQ(merged.size(), 3);
 }
 
 TEST(Index, merge) {

--- a/src/overlaybd/lsmt/test/test.cpp
+++ b/src/overlaybd/lsmt/test/test.cpp
@@ -62,6 +62,30 @@ void lookup_test(const SegmentMapping (&mapping)[N1], Segment s,
     lookup_test<IDX>(mapping, N1, s, stdrst, N2);
 }
 
+TEST_F(FileTest, reject_oversized_index) {
+    const char *filename = "oversized-index.lsmt";
+    auto file = lfs->open(filename, O_RDWR | O_CREAT | O_TRUNC, S_IRWXU);
+    ASSERT_NE(file, nullptr);
+
+    LayerInfo info;
+    info.virtual_size = HeaderTrailer::SPACE;
+    ASSERT_EQ(write_header_trailer(file, true, true, true, 0, 0, info),
+              (int)HeaderTrailer::SPACE);
+
+    const uint64_t index_size = MAX_LSMT_INDEX_SIZE + 1;
+    const uint64_t index_offset = HeaderTrailer::SPACE;
+    const uint64_t trailer_offset =
+        index_offset + index_size * sizeof(SegmentMapping);
+    ASSERT_EQ(file->lseek(trailer_offset, SEEK_SET), (off_t)trailer_offset);
+    ASSERT_EQ(write_header_trailer(file, false, true, true, index_offset,
+                                   index_size, info),
+              (int)HeaderTrailer::SPACE);
+
+    EXPECT_EQ(LSMT::open_file_ro(file), nullptr);
+    delete file;
+    lfs->unlink(filename);
+}
+
 void lookup_test(IMemoryIndex &idx);
 
 TEST(Index, lookup) {

--- a/src/overlaybd/lsmt/test/test.cpp
+++ b/src/overlaybd/lsmt/test/test.cpp
@@ -291,6 +291,27 @@ inline void test_merge_combo(const IMemoryIndex *indexes[], size_t ni, // num of
     test_combo(indexes, ni, stdrst, NR);
 }
 
+TEST(Index, reject_oversized_merge) {
+    const size_t per_index_size = MAX_LSMT_INDEX_SIZE / 2 + 1;
+    vector<SegmentMapping> mapping0;
+    vector<SegmentMapping> mapping1;
+    mapping0.reserve(per_index_size);
+    mapping1.reserve(per_index_size);
+
+    for (size_t i = 0; i < per_index_size; ++i) {
+        mapping0.emplace_back(i * 2, 1, i * 2);
+        mapping1.emplace_back(i * 2 + 1, 1, i * 2 + 1);
+    }
+
+    Index index0(mapping0.data(), mapping0.size(), false);
+    Index index1(mapping1.data(), mapping1.size(), false);
+    const IMemoryIndex *indexes[] = {&index0, &index1};
+
+    auto merged = merge_memory_indexes(indexes, LEN(indexes));
+    EXPECT_EQ(merged, nullptr);
+    delete merged;
+}
+
 TEST(Index, merge) {
     const static SegmentMapping mapping0[] = {{5, 5, 0}, {10, 10, 50}, {100, 10, 20}};
     const static SegmentMapping mapping1[] = {{0, 1, 7},    {2, 4, 5},    {15, 10, 22},

--- a/src/overlaybd/zfile/test/test.cpp
+++ b/src/overlaybd/zfile/test/test.cpp
@@ -133,6 +133,31 @@ public:
     }
 };
 
+TEST_F(ZFileTest, reject_oversized_index) {
+    const char *filename = "oversized-index.zfile";
+    auto file = lfs->open(filename, O_RDWR | O_CREAT | O_TRUNC, 0644);
+    ASSERT_NE(file, nullptr);
+
+    char ht_buf[CompressionFile::HeaderTrailer::SPACE]{};
+    auto ht = new (ht_buf) CompressionFile::HeaderTrailer;
+    CompressOptions opt;
+    ht->set_compress_option(opt);
+    ht->index_offset = CompressionFile::HeaderTrailer::SPACE;
+    ht->index_size = MAX_ZFILE_INDEX_SIZE + 1;
+    ASSERT_EQ(write_header_trailer(file, true, false, true, ht),
+              (int)CompressionFile::HeaderTrailer::SPACE);
+
+    const uint64_t trailer_offset =
+        ht->index_offset + ht->index_size * sizeof(uint32_t);
+    ASSERT_EQ(file->lseek(trailer_offset, SEEK_SET), (off_t)trailer_offset);
+    ASSERT_EQ(write_header_trailer(file, false, true, true, ht),
+              (int)CompressionFile::HeaderTrailer::SPACE);
+
+    EXPECT_EQ(zfile_open_ro(file, false), nullptr);
+    delete file;
+    lfs->unlink(filename);
+}
+
 /*
 testcases:
   checksum{disable, enable} x algorithm{lz4, zstd} x bs{4K, 8K, 16K, 32K, 64K}

--- a/src/overlaybd/zfile/zfile.cpp
+++ b/src/overlaybd/zfile/zfile.cpp
@@ -1075,10 +1075,7 @@ bool load_jump_table(IFile *file, CompressionFile::HeaderTrailer *pheader_traile
         LOG_ERRNO_RETURN(0, false, "failed to stat file.");
     }
     uint64_t index_bytes = 0;
-    uint64_t trailer_offset = 0;
-    bool header_overwrite = pht->is_header_overwrite();
-
-    if (!header_overwrite) {
+    if (!pht->is_header_overwrite()) {
         struct stat stat;
         ret = file->fstat(&stat);
         if (ret < 0) {
@@ -1088,7 +1085,7 @@ bool load_jump_table(IFile *file, CompressionFile::HeaderTrailer *pheader_traile
             LOG_ERROR_RETURN(0, false, "uncognized file type");
         }
 
-        trailer_offset = stat.st_size - CompressionFile::HeaderTrailer::SPACE;
+        auto trailer_offset = stat.st_size - CompressionFile::HeaderTrailer::SPACE;
         ret = file->pread(buf, CompressionFile::HeaderTrailer::SPACE, trailer_offset);
         if (ret < (ssize_t)CompressionFile::HeaderTrailer::SPACE)
             LOG_ERRNO_RETURN(0, false, "failed to read file trailer.");
@@ -1098,15 +1095,12 @@ bool load_jump_table(IFile *file, CompressionFile::HeaderTrailer *pheader_traile
             LOG_ERROR_RETURN(0, false,
                              "trailer magic, trailer type, file type or sealedness doesn't match");
         }
-    }
 
-    if (pht->index_size > MAX_ZFILE_INDEX_SIZE)
-        LOG_ERROR_RETURN(0, false, "ZFile index size ` exceeds maximum `",
-                         pht->index_size + 0, MAX_ZFILE_INDEX_SIZE);
+        if (pht->index_size > MAX_ZFILE_INDEX_SIZE)
+            LOG_ERROR_RETURN(0, false, "ZFile index size ` exceeds maximum `",
+                             pht->index_size + 0, MAX_ZFILE_INDEX_SIZE);
 
-    index_bytes = pht->index_size * sizeof(uint32_t);
-
-    if (!header_overwrite) {
+        index_bytes = pht->index_size * sizeof(uint32_t);
         LOG_INFO("trailer_offset: `, idx_offset: `, idx_bytes: `, dict_size: `, use_dict: `",
                  trailer_offset, pht->index_offset, index_bytes, pht->opt.dict_size,
                  pht->opt.use_dict);
@@ -1114,6 +1108,11 @@ bool load_jump_table(IFile *file, CompressionFile::HeaderTrailer *pheader_traile
         if (index_bytes > trailer_offset - pht->index_offset)
             LOG_ERROR_RETURN(0, false, "invalid index bytes or size. ");
     } else {
+        if (pht->index_size > MAX_ZFILE_INDEX_SIZE)
+            LOG_ERROR_RETURN(0, false, "ZFile index size ` exceeds maximum `",
+                             pht->index_size + 0, MAX_ZFILE_INDEX_SIZE);
+
+        index_bytes = pht->index_size * sizeof(uint32_t);
         LOG_INFO("read overwrite header. idx_offset: `, idx_bytes: `, dict_size: `, use_dict: `",
                  pht->index_offset, index_bytes, pht->opt.dict_size, pht->opt.use_dict);
     }

--- a/src/overlaybd/zfile/zfile.cpp
+++ b/src/overlaybd/zfile/zfile.cpp
@@ -1095,6 +1095,10 @@ bool load_jump_table(IFile *file, CompressionFile::HeaderTrailer *pheader_traile
             LOG_ERROR_RETURN(0, false,
                              "trailer magic, trailer type, file type or sealedness doesn't match");
         }
+
+        if (pht->index_size > MAX_ZFILE_INDEX_SIZE)
+            LOG_ERROR_RETURN(0, false, "ZFile index size ` exceeds maximum `",
+                             pht->index_size + 0, MAX_ZFILE_INDEX_SIZE);
         index_bytes = pht->index_size * sizeof(uint32_t);
         LOG_INFO("trailer_offset: `, idx_offset: `, idx_bytes: `, dict_size: `, use_dict: `",
                  trailer_offset, pht->index_offset, index_bytes, pht->opt.dict_size,
@@ -1103,15 +1107,13 @@ bool load_jump_table(IFile *file, CompressionFile::HeaderTrailer *pheader_traile
         if (index_bytes > trailer_offset - pht->index_offset)
             LOG_ERROR_RETURN(0, false, "invalid index bytes or size. ");
     } else {
+        if (pht->index_size > MAX_ZFILE_INDEX_SIZE)
+            LOG_ERROR_RETURN(0, false, "ZFile index size ` exceeds maximum `",
+                             pht->index_size + 0, MAX_ZFILE_INDEX_SIZE);
         index_bytes = pht->index_size * sizeof(uint32_t);
         LOG_INFO("read overwrite header. idx_offset: `, idx_bytes: `, dict_size: `, use_dict: `",
                  pht->index_offset, index_bytes, pht->opt.dict_size, pht->opt.use_dict);
     }
-
-    if (pht->index_size > MAX_ZFILE_INDEX_SIZE)
-        LOG_ERROR_RETURN(0, false, "ZFile index size ` exceeds maximum `",
-                        pht->index_size + 0, MAX_ZFILE_INDEX_SIZE);
-
     auto ibuf = std::unique_ptr<uint32_t[]>(new uint32_t[pht->index_size]);
     LOG_DEBUG("index_offset: `", pht->index_offset);
 

--- a/src/overlaybd/zfile/zfile.cpp
+++ b/src/overlaybd/zfile/zfile.cpp
@@ -1075,7 +1075,10 @@ bool load_jump_table(IFile *file, CompressionFile::HeaderTrailer *pheader_traile
         LOG_ERRNO_RETURN(0, false, "failed to stat file.");
     }
     uint64_t index_bytes = 0;
-    if (!pht->is_header_overwrite()) {
+    uint64_t trailer_offset = 0;
+    bool header_overwrite = pht->is_header_overwrite();
+
+    if (!header_overwrite) {
         struct stat stat;
         ret = file->fstat(&stat);
         if (ret < 0) {
@@ -1085,7 +1088,7 @@ bool load_jump_table(IFile *file, CompressionFile::HeaderTrailer *pheader_traile
             LOG_ERROR_RETURN(0, false, "uncognized file type");
         }
 
-        auto trailer_offset = stat.st_size - CompressionFile::HeaderTrailer::SPACE;
+        trailer_offset = stat.st_size - CompressionFile::HeaderTrailer::SPACE;
         ret = file->pread(buf, CompressionFile::HeaderTrailer::SPACE, trailer_offset);
         if (ret < (ssize_t)CompressionFile::HeaderTrailer::SPACE)
             LOG_ERRNO_RETURN(0, false, "failed to read file trailer.");
@@ -1095,25 +1098,26 @@ bool load_jump_table(IFile *file, CompressionFile::HeaderTrailer *pheader_traile
             LOG_ERROR_RETURN(0, false,
                              "trailer magic, trailer type, file type or sealedness doesn't match");
         }
+    }
 
-        if (pht->index_size > MAX_ZFILE_INDEX_SIZE)
-            LOG_ERROR_RETURN(0, false, "ZFile index size ` exceeds maximum `",
-                             pht->index_size + 0, MAX_ZFILE_INDEX_SIZE);
-        index_bytes = pht->index_size * sizeof(uint32_t);
+    if (pht->index_size > MAX_ZFILE_INDEX_SIZE)
+        LOG_ERROR_RETURN(0, false, "ZFile index size ` exceeds maximum `",
+                        pht->index_size + 0, MAX_ZFILE_INDEX_SIZE);
+
+    index_bytes = pht->index_size * sizeof(uint32_t);
+
+    if (!header_overwrite) {
         LOG_INFO("trailer_offset: `, idx_offset: `, idx_bytes: `, dict_size: `, use_dict: `",
-                 trailer_offset, pht->index_offset, index_bytes, pht->opt.dict_size,
-                 pht->opt.use_dict);
+                trailer_offset, pht->index_offset, index_bytes, pht->opt.dict_size,
+                pht->opt.use_dict);
 
         if (index_bytes > trailer_offset - pht->index_offset)
             LOG_ERROR_RETURN(0, false, "invalid index bytes or size. ");
     } else {
-        if (pht->index_size > MAX_ZFILE_INDEX_SIZE)
-            LOG_ERROR_RETURN(0, false, "ZFile index size ` exceeds maximum `",
-                             pht->index_size + 0, MAX_ZFILE_INDEX_SIZE);
-        index_bytes = pht->index_size * sizeof(uint32_t);
         LOG_INFO("read overwrite header. idx_offset: `, idx_bytes: `, dict_size: `, use_dict: `",
                  pht->index_offset, index_bytes, pht->opt.dict_size, pht->opt.use_dict);
     }
+
     auto ibuf = std::unique_ptr<uint32_t[]>(new uint32_t[pht->index_size]);
     LOG_DEBUG("index_offset: `", pht->index_offset);
 

--- a/src/overlaybd/zfile/zfile.cpp
+++ b/src/overlaybd/zfile/zfile.cpp
@@ -47,6 +47,7 @@ uint64_t zfile_blk_cnt = 0;
 namespace ZFile {
 
 const static size_t BUF_SIZE = 512;
+const static uint64_t MAX_ZFILE_INDEX_SIZE = 1000000000;
 const static uint32_t NOI_WELL_KNOWN_PRIME = 100007;
 const static uint8_t FLAG_VALID_FALSE = 0;
 const static uint8_t FLAG_VALID_TRUE = 1;
@@ -1094,7 +1095,9 @@ bool load_jump_table(IFile *file, CompressionFile::HeaderTrailer *pheader_traile
             LOG_ERROR_RETURN(0, false,
                              "trailer magic, trailer type, file type or sealedness doesn't match");
         }
-
+        if (pht->index_size > MAX_ZFILE_INDEX_SIZE)
+            LOG_ERROR_RETURN(0, false, "ZFile index size ` exceeds maximum `",
+                            pht->index_size + 0, MAX_ZFILE_INDEX_SIZE);
         index_bytes = pht->index_size * sizeof(uint32_t);
         LOG_INFO("trailer_offset: `, idx_offset: `, idx_bytes: `, dict_size: `, use_dict: `",
                  trailer_offset, pht->index_offset, index_bytes, pht->opt.dict_size,
@@ -1103,6 +1106,9 @@ bool load_jump_table(IFile *file, CompressionFile::HeaderTrailer *pheader_traile
         if (index_bytes > trailer_offset - pht->index_offset)
             LOG_ERROR_RETURN(0, false, "invalid index bytes or size. ");
     } else {
+        if (pht->index_size > MAX_ZFILE_INDEX_SIZE)
+            LOG_ERROR_RETURN(0, false, "ZFile index size ` exceeds maximum `",
+                     pht->index_size + 0, MAX_ZFILE_INDEX_SIZE);
         index_bytes = pht->index_size * sizeof(uint32_t);
         LOG_INFO("read overwrite header. idx_offset: `, idx_bytes: `, dict_size: `, use_dict: `",
                  pht->index_offset, index_bytes, pht->opt.dict_size, pht->opt.use_dict);

--- a/src/overlaybd/zfile/zfile.cpp
+++ b/src/overlaybd/zfile/zfile.cpp
@@ -1116,7 +1116,6 @@ bool load_jump_table(IFile *file, CompressionFile::HeaderTrailer *pheader_traile
         LOG_INFO("read overwrite header. idx_offset: `, idx_bytes: `, dict_size: `, use_dict: `",
                  pht->index_offset, index_bytes, pht->opt.dict_size, pht->opt.use_dict);
     }
-
     auto ibuf = std::unique_ptr<uint32_t[]>(new uint32_t[pht->index_size]);
     LOG_DEBUG("index_offset: `", pht->index_offset);
 

--- a/src/overlaybd/zfile/zfile.cpp
+++ b/src/overlaybd/zfile/zfile.cpp
@@ -1095,9 +1095,6 @@ bool load_jump_table(IFile *file, CompressionFile::HeaderTrailer *pheader_traile
             LOG_ERROR_RETURN(0, false,
                              "trailer magic, trailer type, file type or sealedness doesn't match");
         }
-        if (pht->index_size > MAX_ZFILE_INDEX_SIZE)
-            LOG_ERROR_RETURN(0, false, "ZFile index size ` exceeds maximum `",
-                            pht->index_size + 0, MAX_ZFILE_INDEX_SIZE);
         index_bytes = pht->index_size * sizeof(uint32_t);
         LOG_INFO("trailer_offset: `, idx_offset: `, idx_bytes: `, dict_size: `, use_dict: `",
                  trailer_offset, pht->index_offset, index_bytes, pht->opt.dict_size,
@@ -1106,13 +1103,15 @@ bool load_jump_table(IFile *file, CompressionFile::HeaderTrailer *pheader_traile
         if (index_bytes > trailer_offset - pht->index_offset)
             LOG_ERROR_RETURN(0, false, "invalid index bytes or size. ");
     } else {
-        if (pht->index_size > MAX_ZFILE_INDEX_SIZE)
-            LOG_ERROR_RETURN(0, false, "ZFile index size ` exceeds maximum `",
-                     pht->index_size + 0, MAX_ZFILE_INDEX_SIZE);
         index_bytes = pht->index_size * sizeof(uint32_t);
         LOG_INFO("read overwrite header. idx_offset: `, idx_bytes: `, dict_size: `, use_dict: `",
                  pht->index_offset, index_bytes, pht->opt.dict_size, pht->opt.use_dict);
     }
+
+    if (pht->index_size > MAX_ZFILE_INDEX_SIZE)
+        LOG_ERROR_RETURN(0, false, "ZFile index size ` exceeds maximum `",
+                        pht->index_size + 0, MAX_ZFILE_INDEX_SIZE);
+
     auto ibuf = std::unique_ptr<uint32_t[]>(new uint32_t[pht->index_size]);
     LOG_DEBUG("index_offset: `", pht->index_offset);
 

--- a/src/overlaybd/zfile/zfile.cpp
+++ b/src/overlaybd/zfile/zfile.cpp
@@ -1102,14 +1102,14 @@ bool load_jump_table(IFile *file, CompressionFile::HeaderTrailer *pheader_traile
 
     if (pht->index_size > MAX_ZFILE_INDEX_SIZE)
         LOG_ERROR_RETURN(0, false, "ZFile index size ` exceeds maximum `",
-                        pht->index_size + 0, MAX_ZFILE_INDEX_SIZE);
+                         pht->index_size + 0, MAX_ZFILE_INDEX_SIZE);
 
     index_bytes = pht->index_size * sizeof(uint32_t);
 
     if (!header_overwrite) {
         LOG_INFO("trailer_offset: `, idx_offset: `, idx_bytes: `, dict_size: `, use_dict: `",
-                trailer_offset, pht->index_offset, index_bytes, pht->opt.dict_size,
-                pht->opt.use_dict);
+                 trailer_offset, pht->index_offset, index_bytes, pht->opt.dict_size,
+                 pht->opt.use_dict);
 
         if (index_bytes > trailer_offset - pht->index_offset)
             LOG_ERROR_RETURN(0, false, "invalid index bytes or size. ");


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds index-size validation when loading LSMT and ZFile files.

- Rejects LSMT indexes containing more than 1,000,000 records.
- Rejects ZFile indexes containing more than 1,000,000,000 records.
- Performs validation before calculating index memory requirements.
- Adds regression tests confirming oversized indexes are rejected.

**Which issue(s) this PR fixes**:

N/A

**Tests**:

- `./build/output/lsmt_test --gtest_filter=FileTest.reject_oversized_index`
- `./build/output/zfile_test --gtest_filter=ZFileTest.reject_oversized_index`

Both tests passed.

**Please check the following list**:
- [x] The affected code has corresponding unit tests.
- [x] This change does not require a documentation update.
- [x] This change does not introduce breaking changes.
- [x] No new files were added.