### PR TITLE
[Bugfix] prefetcher deconstruct, erofs lstat, auto registry cache dir and legacy .commit support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ build
 releases
 .vscode
 .idea
+deps/

--- a/src/image_file.cpp
+++ b/src/image_file.cpp
@@ -266,19 +266,18 @@ void *do_parallel_open_files(ImageFile *imgfile, ParallelOpenTask &tm) {
 }
 
 IFile *ImageFile::open_localfile(ImageConfigNS::LayerConfig &layer, std::string &opened) {
-    if (layer.file() != "") {
-        opened = layer.file();
-        return __open_ro_file(opened);
-    }
-    if (BKDL::check_downloaded(layer.dir())) {
-        opened = layer.dir() + "/" + COMMIT_FILE_NAME;
-        return __open_ro_file(opened);
-    }
-    auto sealed = layer.dir() + "/" + SEALED_FILE_NAME;
-    if (::access(sealed.c_str(), 0) == 0) {
-        // open sealed blob
-        opened = sealed;
-        return __open_ro_file(opened);
+    const std::string candidates[] = {
+        layer.file(),
+        layer.dir() + "/" + COMMIT_FILE_NAME,
+        layer.dir() + "/" + LEGACY_COMMIT_FILE_NAME,
+        layer.dir() + "/" + SEALED_FILE_NAME
+    };
+
+    for (const auto &path : candidates) {
+        if (::access(path.c_str(), F_OK) == 0) {
+            opened = path;
+            return __open_ro_file(opened);
+        }
     }
     return nullptr;
 }
@@ -583,10 +582,10 @@ int ImageFile::create_snapshot(const char *new_config_path) {
     upper_file = open_upper(upper);
     if (!upper_file)
         LOG_ERROR_RETURN(0, -1, "Open upper layer failed.");
-    
+
     if(((LSMT::IFileRW *)m_file)->restack(upper_file) != 0)
         LOG_ERRNO_RETURN(0, -1, "Restack new rwlayer failed.");
-    
+
     if(m_upper_file) {
         // transfer the sealed layer from m_upper_file to m_lower_file before m_upper_file is destructed
         auto sealed = ((LSMT::IFileRW *)m_upper_file)->get_file(0);
@@ -614,7 +613,7 @@ int ImageFile::create_snapshot(const char *new_config_path) {
         LOG_ERRNO_RETURN(0, -1, "rename(`,`) failed", new_config_path, this->config_path);
     }
     LOG_INFO("rename(`,`) success", new_config_path, this->config_path);
-    
+
     return 0;
 }
 

--- a/src/image_file.h
+++ b/src/image_file.h
@@ -38,6 +38,7 @@
 
 static std::string COMMIT_FILE_NAME = "overlaybd.commit";
 static std::string SEALED_FILE_NAME = "overlaybd.sealed";
+static std::string LEGACY_COMMIT_FILE_NAME = ".commit";
 
 class ImageFile : public photon::fs::ForwardFile {
 public:

--- a/src/image_service.cpp
+++ b/src/image_service.cpp
@@ -46,20 +46,17 @@ struct ImageRef {
     std::vector<std::string> seg; // cr: seg_0, ns: seg_1, repo: seg_2, seg_3,...
 };
 
-bool create_dir(const char *dirname) {
+bool create_dir(const std::string &dirname) {
     auto lfs = new_localfs_adaptor();
     if (lfs == nullptr) {
         LOG_ERRNO_RETURN(0, false, "new localfs_adaptor failed");
     }
     DEFER(delete lfs);
-    if (lfs->access(dirname, 0) == 0) {
-        return true;
+
+    if (photon::fs::mkdir_recursive(dirname+"/", lfs, 0755)) {
+        LOG_ERRNO_RETURN(0, false, "failed to create dir `", dirname);
     }
-    if (lfs->mkdir(dirname, 0644) == 0) {
-        LOG_INFO("dir ` doesn't exist. create succ.", dirname);
-        return true;
-    }
-    LOG_ERRNO_RETURN(0, false, "dir ` doesn't exist. create failed.", dirname);
+    return true;
 }
 
 int parse_blob_url(const std::string &url, struct ImageRef &ref) {
@@ -640,7 +637,7 @@ ImageService::~ImageService() {
     delete global_fs.io_alloc;
     delete exporter;
     stop_api_server(api_server);
-    
+
     LOG_INFO("image service is fully stopped");
 }
 

--- a/src/overlaybd/tar/erofs/erofs_fs.cpp
+++ b/src/overlaybd/tar/erofs/erofs_fs.cpp
@@ -20,6 +20,8 @@
 #include "erofs/dir.h"
 #include <dirent.h>
 #include <vector>
+#include <photon/fs/path.h>
+#include <photon/common/alog-stdstring.h>
 
 struct ErofsFileSystem::ErofsFileSystemInt {
 	struct erofs_sb_info sbi;
@@ -204,6 +206,37 @@ static int do_erofs_ilookup(const char *path, struct erofs_inode *vi)
 	return erofs_read_inode_from_disk(vi);
 }
 
+static int do_erofs_ilookup_not_follow(const char *path, struct erofs_inode *vi) {
+    size_t len = strlen(path);
+    while (len > 0 && path[len - 1] == '/') {
+        len--;
+    }
+    if (len == 0) {
+        // root case
+        return do_erofs_ilookup(path, vi);
+    }
+    photon::fs::Path p(std::string_view(path, len));
+    std::string dirname(p.dirname());
+    std::string basename(p.basename());
+    struct liberofs_nameidata nd = {.sbi = vi->sbi};
+    nd.nid = vi->sbi->root_nid;
+    auto ret = liberofs_link_path_walk(dirname.c_str(), &nd);
+    if (ret) {
+        LOG_ERRNO_RETURN(0, ret, "failed to namei parent", VALUE(path), VALUE(dirname));
+    }
+    ret = liberofs_namei(&nd, basename.c_str(), basename.length());
+    if (ret) {
+        LOG_ERRNO_RETURN(0, ret, "failed to namei", VALUE(path), VALUE(basename));
+    }
+    vi->sbi = nd.sbi;
+    vi->nid = nd.nid;
+    ret = erofs_read_inode_from_disk(vi);
+    if (ret) {
+        LOG_ERRNO_RETURN(0, ret, "failed to read inode", VALUE(path));
+    }
+    return 0;
+}
+
 int ErofsFile::fstat(struct stat *buf)
 {
 	buf->st_mode = file_private->inode.i_mode;
@@ -329,7 +362,6 @@ EROFS_UNIMPLEMENTED_FUNC(int, ErofsFileSystem, chown(const char *pathname, uid_t
 EROFS_UNIMPLEMENTED_FUNC(int, ErofsFileSystem, lchown(const char *pathname, uid_t owner, gid_t group), -EROFS_UNIMPLEMENTED)
 EROFS_UNIMPLEMENTED_FUNC(int, ErofsFileSystem, statfs(const char *path, struct statfs *buf), -EROFS_UNIMPLEMENTED)
 EROFS_UNIMPLEMENTED_FUNC(int, ErofsFileSystem, statvfs(const char *path, struct statvfs *buf), -EROFS_UNIMPLEMENTED)
-EROFS_UNIMPLEMENTED_FUNC(int, ErofsFileSystem, lstat(const char *path, struct stat *buf), -EROFS_UNIMPLEMENTED)
 EROFS_UNIMPLEMENTED_FUNC(int, ErofsFileSystem, access(const char *pathname, int mode), -EROFS_UNIMPLEMENTED)
 EROFS_UNIMPLEMENTED_FUNC(int, ErofsFileSystem, truncate(const char *path, off_t length), -EROFS_UNIMPLEMENTED)
 EROFS_UNIMPLEMENTED_FUNC(int, ErofsFileSystem, utime(const char *path, const struct utimbuf *file_times), -EROFS_UNIMPLEMENTED)
@@ -398,6 +430,26 @@ int ErofsFileSystem::stat(const char *path, struct stat *buf)
 	return 0;
 }
 
+int ErofsFileSystem::lstat(const char *path, struct stat *buf)
+{
+    struct erofs_inode vi;
+    int err;
+    vi.sbi = &fs_private->sbi;
+    err = do_erofs_ilookup_not_follow(path, &vi);
+    if (err)
+        LOG_ERRNO_RETURN(err, err, "[erofs] Fail to lookup inode");
+    buf->st_mode = vi.i_mode;
+    buf->st_nlink = vi.i_nlink;
+    buf->st_size = vi.i_size;
+    buf->st_blocks = roundup(vi.i_size, erofs_blksiz(vi.sbi)) >> 9;
+    buf->st_uid = vi.i_uid;
+    buf->st_gid = vi.i_gid;
+    buf->st_ctime = vi.i_mtime;
+    buf->st_mtime = vi.i_mtime;
+    buf->st_atime = vi.i_mtime;
+    return 0;
+}
+
 photon::fs::IFile* ErofsFileSystem::open(const char *pathname, int flags)
 {
 	ErofsFile *file = new ErofsFile(this);
@@ -406,7 +458,7 @@ photon::fs::IFile* ErofsFileSystem::open(const char *pathname, int flags)
 	err = do_erofs_ilookup(pathname, &file->file_private->inode);
 	if (err) {
 		delete file;
-		LOG_ERROR_RETURN(-err, nullptr, "[erofs] Fail to lookup inode by path");
+		LOG_ERROR_RETURN(-err, nullptr, "[erofs] Fail to lookup inode by path", VALUE(pathname));
 	}
 	return file;
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR bundles several small but independent fixes/improvements:

- **prefetch: fix prefetcher deconstruct**  
  Rework the `DynamicPrefetcher` lifecycle so that the replay thread is stopped inside `~DynamicPrefetcher()` instead of the parent destructor, avoiding use-after-free when `generate_trace()` is still running. Also removes the unused `m_reload_thread`, fixes empty-record early return, and checks `m_replay_stopped` while generating traces.

- **erofs: implement `lstat()` for dynamic prefetcher**  
  Dynamic prefetching on directories needs to resolve paths without following symlinks. Adds `do_erofs_ilookup_not_follow()` and a real `ErofsFileSystem::lstat()` implementation.

- **image_service: auto `mkdir -p` registry cache dir**  
  Replace the manual `access` + `mkdir` logic with `photon::fs::mkdir_recursive` so nested registry cache directories are created automatically.

- **image_file: support legacy local `.commit` file**  
  Some older tooling emits `.commit` as the local layer file name. Refactor `open_localfile()` to probe candidates in order (`layer.file()`, `overlaybd.commit`, legacy `.commit`, `overlaybd.sealed`) and accept the first existing one.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Please check the following list**:
- [ ]  Does the affected code have corresponding tests, e.g. unit test, E2E test?
- [ ]  Does this change require a documentation update?
- [ ]  Does this introduce breaking changes that would require an announcement or bumping the major version?
- [ ]  Do all new files have an appropriate license header?