### PR TITLE
Disable resize support in Photon when building with an external e2fs

### DIFF
--- a/CMake/Findphoton.cmake
+++ b/CMake/Findphoton.cmake
@@ -1,8 +1,11 @@
 include(FetchContent)
 set(FETCHCONTENT_QUIET false)
 set(PHOTON_ENABLE_EXTFS ON)
-set(PHOTON_ENABLE_RESIZE ON)
-add_definitions(-DPHOTON_ENABLE_RESIZE)
+
+if(NOT ORIGIN_EXT2FS)
+  set(PHOTON_ENABLE_RESIZE ON)
+  add_definitions(-DPHOTON_ENABLE_RESIZE)
+endif()
 
 FetchContent_Declare(
   photon


### PR DESCRIPTION
**What this PR does / why we need it**:

Otherwise the build will fail due to unresolved symbols.

**Please check the following list**:
- [ ]  Does the affected code have corresponding tests, e.g. unit test, E2E test? N/A
- [ ]  Does this change require a documentation update? No
- [ ]  Does this introduce breaking changes that would require an announcement or bumping the major version? No
- [ ]  Do all new files have an appropriate license header? N/A