### PR TITLE
Add ARM64 NEON and SVE acceleration for LSMT inner search

### DIFF
--- a/src/overlaybd/lsmt/CMakeLists.txt
+++ b/src/overlaybd/lsmt/CMakeLists.txt
@@ -1,9 +1,50 @@
 file(GLOB SOURCE_LSMT "*.cpp")
 
+# index_sve.cpp must not be compiled unconditionally: it requires a
+# toolchain that supports SVE code generation (gcc >= 10, via ACLE
+# <arm_sve.h>). Exclude it from the glob and re-add only when the
+# toolchain probe passes, so older toolchains (e.g. devtoolset-7)
+# keep building without it.
+list(REMOVE_ITEM SOURCE_LSMT "${CMAKE_CURRENT_SOURCE_DIR}/index_sve.cpp")
+
 add_library(lsmt_lib STATIC ${SOURCE_LSMT})
 target_include_directories(lsmt_lib PUBLIC
     ${PHOTON_INCLUDE_DIR}
 )
+
+if(CMAKE_SYSTEM_PROCESSOR MATCHES "^(aarch64|arm64)$")
+  option(OVERLAYBD_DISABLE_SVE "Force-disable LSMT SVE acceleration" OFF)
+  include(CheckCXXCompilerFlag)
+  include(CheckCXXSourceCompiles)
+  if(NOT OVERLAYBD_DISABLE_SVE)
+  check_cxx_compiler_flag("-march=armv8.2-a+sve" COMPILER_HAS_SVE_FLAG)
+  set(SVE_PROBE_SOURCE "#include <arm_sve.h>
+#include <cstdint>
+extern \"C\" uint32_t probe(const uint32_t *p, uint32_t x) {
+  svbool_t pg = svwhilelt_b32(0UL, 4UL);
+  svuint32_t d = svld1_u32(pg, p);
+  svbool_t c = svcmple_u32(pg, d, svdup_u32(x));
+  return (uint32_t)svaddv_u32(c, svdup_u32(1));
+}
+int main() { return 0; }
+")
+  set(CMAKE_REQUIRED_FLAGS "-march=armv8.2-a+sve")
+  check_cxx_source_compiles("${SVE_PROBE_SOURCE}" SVE_HEADER_USABLE)
+  unset(CMAKE_REQUIRED_FLAGS)
+  if(COMPILER_HAS_SVE_FLAG AND SVE_HEADER_USABLE)
+    target_sources(lsmt_lib PRIVATE index_sve.cpp)
+    # armv8.2-a is the minimal architecture baseline that can carry the
+    # +sve extension -- a permission floor for code generation, not a
+    # per-generation target: newer SVE hardware runs this same object
+    # unchanged, and runtime dispatch (HWCAP_SVE) gates execution.
+    set_source_files_properties(index_sve.cpp PROPERTIES COMPILE_OPTIONS "-march=armv8.2-a+sve")
+    target_compile_definitions(lsmt_lib PUBLIC OVERLAYBD_ENABLE_SVE)
+    message(STATUS "LSMT SVE acceleration: ENABLED")
+  else()
+    message(STATUS "LSMT SVE acceleration: DISABLED (toolchain probe failed)")
+  endif()
+  endif() # OVERLAYBD_DISABLE_SVE
+endif()
 
 if(BUILD_TESTING)
   add_subdirectory(test)

--- a/src/overlaybd/lsmt/index.cpp
+++ b/src/overlaybd/lsmt/index.cpp
@@ -26,6 +26,10 @@
 #ifdef __x86_64__
 #include <immintrin.h>
 #endif
+#ifdef __aarch64__
+#include <arm_neon.h>
+#include <sys/auxv.h>
+#endif
 using namespace std;
 
 namespace LSMT {
@@ -67,6 +71,24 @@ bool is_avx512f_supported() {
 #endif
 }
 
+#if defined(__aarch64__)
+// Runtime capability ladder on aarch64: SVE2 / SVE1 / NEON / scalar.
+// HWCAP_SVE gates the SVE code path; HWCAP2_SVE2 only refines tier
+// reporting -- this kernel uses no SVE2-only instructions, and SVE1 code
+// is a strict architectural subset of SVE2.
+bool sve_supported() {
+    return getauxval(AT_HWCAP) & (1UL << 22); // HWCAP_SVE
+}
+
+bool sve2_supported() {
+#ifdef AT_HWCAP2
+    return getauxval(AT_HWCAP2) & (1UL << 1); // HWCAP2_SVE2
+#else
+    return false;
+#endif
+}
+#endif // __aarch64__
+
 const static uint32_t KEYS_PER_NODE_64 = 8;
 const static uint32_t MAX_LEVEL_64 = 10;
 static constexpr uint32_t NODES_PER_LEVEL_64[MAX_LEVEL_64] = {8, 72, 648, 5832, 52488, 472392, 4251528, 38263752, 344373768, 3099363912};
@@ -93,6 +115,88 @@ struct DefaultInnerSearch {
         return __builtin_popcount(mask);
     }
 };
+
+#ifdef __aarch64__
+// AdvSIMD (NEON) inner search: counts keys <= x among the node's keys,
+// semantics identical to DefaultInnerSearch. NEON is architecturally
+// mandatory on aarch64, so this tier needs no runtime capability check.
+template<typename KeyType> struct NeonInnerSearchImpl;
+
+template<> struct NeonInnerSearchImpl<uint32_t> {
+    static uint32_t inner_search(const uint32_t *base, uint32_t x) {
+        uint32x4_t vx = vdupq_n_u32(x);
+        uint32_t c = 0;
+        c += vaddvq_u32(vshrq_n_u32(vcleq_u32(vld1q_u32(base), vx), 31));
+        c += vaddvq_u32(vshrq_n_u32(vcleq_u32(vld1q_u32(base + 4), vx), 31));
+        c += vaddvq_u32(vshrq_n_u32(vcleq_u32(vld1q_u32(base + 8), vx), 31));
+        c += vaddvq_u32(vshrq_n_u32(vcleq_u32(vld1q_u32(base + 12), vx), 31));
+        return c;
+    }
+};
+
+template<> struct NeonInnerSearchImpl<uint64_t> {
+    static uint32_t inner_search(const uint64_t *base, uint64_t x) {
+        uint64x2_t vx = vdupq_n_u64(x);
+        uint64_t c = 0;
+        c += vaddvq_u64(vshrq_n_u64(vcleq_u64(vld1q_u64(base), vx), 63));
+        c += vaddvq_u64(vshrq_n_u64(vcleq_u64(vld1q_u64(base + 2), vx), 63));
+        c += vaddvq_u64(vshrq_n_u64(vcleq_u64(vld1q_u64(base + 4), vx), 63));
+        c += vaddvq_u64(vshrq_n_u64(vcleq_u64(vld1q_u64(base + 6), vx), 63));
+        return (uint32_t)c;
+    }
+};
+
+template<typename KeyType>
+struct NeonInnerSearch {
+    static uint32_t inner_search(const KeyType *base, KeyType x) {
+        return NeonInnerSearchImpl<KeyType>::inner_search(base, x);
+    }
+};
+
+// C-linkage bridges so the test binary (test/inner_search_test.cpp) can
+// exercise the NEON kernels directly, mirroring the SVE TU's interface.
+extern "C" uint32_t lsmt_neon_inner_search_u32(const uint32_t *base, uint32_t x) {
+    return NeonInnerSearch<uint32_t>::inner_search(base, x);
+}
+extern "C" uint32_t lsmt_neon_inner_search_u64(const uint64_t *base, uint64_t x) {
+    return NeonInnerSearch<uint64_t>::inner_search(base, x);
+}
+#endif // __aarch64__
+
+#if defined(__aarch64__) && defined(OVERLAYBD_ENABLE_SVE)
+// SVE1 inner search, bridged to the separately-compiled SVE TU
+// (index_sve.cpp, compiled with -march=armv8.2-a+sve). SVE1 code is a
+// strict architectural subset of SVE2, so this same code also serves
+// SVE2-capable hardware; benefits scale with the runtime vector length.
+// NOTE: never compile this TU with +sve2 -- hardware without SVE2
+// would fault on SVE2 instructions.
+extern "C" {
+uint32_t lsmt_sve_inner_search_u32(const uint32_t *base, uint32_t x);
+uint32_t lsmt_sve_inner_search_u64(const uint64_t *base, uint64_t x);
+uint32_t lsmt_sve_vl_bytes();
+}
+
+template<typename KeyType> struct SveInnerSearchImpl;
+
+template<> struct SveInnerSearchImpl<uint32_t> {
+    static uint32_t inner_search(const uint32_t *base, uint32_t x) {
+        return lsmt_sve_inner_search_u32(base, x);
+    }
+};
+
+template<> struct SveInnerSearchImpl<uint64_t> {
+    static uint32_t inner_search(const uint64_t *base, uint64_t x) {
+        return lsmt_sve_inner_search_u64(base, x);
+    }
+};
+
+template<typename KeyType>
+struct SveInnerSearch {
+    static uint32_t inner_search(const KeyType *base, KeyType x) {
+        return SveInnerSearchImpl<KeyType>::inner_search(base, x);
+    }
+};
+#endif // SVE bridge
 
 #ifdef __x86_64__
 template<typename KeyType>
@@ -359,6 +463,15 @@ public:
 template<typename KeyType>
 using IndexLBPTAcc = IndexLBPT<KeyType, Avx512InnerSearch>;
 
+#ifdef __aarch64__
+template<typename KeyType>
+using IndexLBPTNeon = IndexLBPT<KeyType, NeonInnerSearch>;
+#if defined(OVERLAYBD_ENABLE_SVE)
+template<typename KeyType>
+using IndexLBPTSve = IndexLBPT<KeyType, SveInnerSearch>;
+#endif
+#endif
+
 template <typename KeyType>
 static inline Index* new_index_with_lineriazed_bptree(vector<SegmentMapping> &&m, uint64_t vsize = 0) {
     static_assert(std::is_same<KeyType, uint32_t>::value || std::is_same<KeyType, uint64_t>::value,
@@ -374,6 +487,17 @@ static inline Index* new_index_with_lineriazed_bptree(vector<SegmentMapping> &&m
         LOG_INFO("using accelerated search for linearized b+tree");
         return new IndexLBPTAcc<KeyType>(std::move(m), vsize, tree);
     }
+#if defined(__aarch64__) && defined(OVERLAYBD_ENABLE_SVE)
+    if (sve_supported()) {
+        LOG_INFO("using SVE search for linearized b+tree, tier=",
+                 sve2_supported() ? "SVE2" : "SVE1", ", vl_bytes=", lsmt_sve_vl_bytes());
+        return new IndexLBPTSve<KeyType>(std::move(m), vsize, tree);
+    }
+#endif
+#ifdef __aarch64__
+    LOG_INFO("using NEON search for linearized b+tree, tier=NEON");
+    return new IndexLBPTNeon<KeyType>(std::move(m), vsize, tree);
+#endif
     return new IndexLBPT<KeyType>(std::move(m), vsize, tree);
 }
 
@@ -979,4 +1103,5 @@ IMemoryIndex *merge_memory_indexes(const IMemoryIndex **pindexes, size_t n) {
 
     return new_index_with_lineriazed_bptree<uint64_t>(std::move(mapping), pindexes[0]->vsize());
 }
+
 } // namespace LSMT

--- a/src/overlaybd/lsmt/index_sve.cpp
+++ b/src/overlaybd/lsmt/index_sve.cpp
@@ -1,0 +1,58 @@
+/*
+Copyright The Overlaybd Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// SVE1 implementation of the LSMT B+tree inner search.
+//
+// This TU is compiled with -march=armv8.2-a+sve (SVE1, NOT +sve2).
+// armv8.2-a is the minimal architecture baseline that can carry the
+// +sve extension -- a permission floor for code generation, not a
+// per-generation target: SVE hardware is at least ARMv8.2-A, newer
+// generations run this same binary unchanged, and runtime dispatch
+// (HWCAP_SVE) decides whether this path is taken at all.
+// SVE1 code is a strict architectural subset of SVE2, so the same
+// code serves SVE1 and SVE2-capable hardware. Never compile this TU
+// with +sve2 -- hardware without SVE2 would fault with SIGILL on
+// SVE2 instructions.
+#include <cstdint>
+#include <arm_sve.h>
+
+extern "C" uint32_t lsmt_sve_inner_search_u32(const uint32_t *base, uint32_t x) {
+    uint32_t cnt = 0;
+    for (uint32_t i = 0; i < 16;) {
+        svbool_t pg = svwhilelt_b32((uint64_t)i, (uint64_t)16);
+        svuint32_t d = svld1_u32(pg, base + i);
+        svbool_t c = svcmple_u32(pg, d, svdup_u32(x));
+        cnt += (uint32_t)svcntp_b32(pg, c);
+        i += svcntw();
+    }
+    return cnt;
+}
+
+extern "C" uint32_t lsmt_sve_inner_search_u64(const uint64_t *base, uint64_t x) {
+    uint32_t cnt = 0;
+    for (uint32_t i = 0; i < 8;) {
+        svbool_t pg = svwhilelt_b64((uint64_t)i, (uint64_t)8);
+        svuint64_t d = svld1_u64(pg, base + i);
+        svbool_t c = svcmple_u64(pg, d, svdup_u64(x));
+        cnt += (uint32_t)svcntp_b64(pg, c);
+        i += svcntd();
+    }
+    return cnt;
+}
+
+extern "C" uint32_t lsmt_sve_vl_bytes() {
+    return svcntb();
+}

--- a/src/overlaybd/lsmt/test/CMakeLists.txt
+++ b/src/overlaybd/lsmt/test/CMakeLists.txt
@@ -4,9 +4,13 @@ link_directories($ENV{GFLAGS}/lib)
 include_directories($ENV{GTEST}/googletest/include)
 link_directories($ENV{GTEST}/lib)
 
-add_executable(lsmt_test test.cpp)
+add_executable(lsmt_test test.cpp inner_search_test.cpp)
 target_include_directories(lsmt_test PUBLIC ${PHOTON_INCLUDE_DIR})
 target_link_libraries(lsmt_test gtest gtest_main gflags pthread photon_static overlaybd_lib)
+
+# Recent googletest releases (e.g. Fedora 44) require C++17; the library
+# itself stays on the project-wide C++14.
+set_property(TARGET lsmt_test PROPERTY CXX_STANDARD 17)
 
 add_test(
   NAME lsmt_test

--- a/src/overlaybd/lsmt/test/inner_search_test.cpp
+++ b/src/overlaybd/lsmt/test/inner_search_test.cpp
@@ -17,8 +17,7 @@
 // Cross-validation of the aarch64 inner-search kernels (NEON, SVE) against
 // an independent scalar reference implemented here in the test. Kernel level
 // only: randomized + boundary inputs on single nodes (16x u32 / 8x u64).
-// Tree-level integration is exercised on real hardware via the dispatch
-// tier log (see docs/lsmt_arm64_sve_code.md for the full story).
+// Tree-level integration is exercised on real hardware via the dispatch tier log.
 #include <gtest/gtest.h>
 #include <cstdint>
 

--- a/src/overlaybd/lsmt/test/inner_search_test.cpp
+++ b/src/overlaybd/lsmt/test/inner_search_test.cpp
@@ -1,0 +1,152 @@
+/*
+   Copyright The Overlaybd Authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+// Cross-validation of the aarch64 inner-search kernels (NEON, SVE) against
+// an independent scalar reference implemented here in the test. Kernel level
+// only: randomized + boundary inputs on single nodes (16x u32 / 8x u64).
+// Tree-level integration is exercised on real hardware via the dispatch
+// tier log (see docs/lsmt_arm64_sve_code.md for the full story).
+#include <gtest/gtest.h>
+#include <cstdint>
+
+#if defined(__aarch64__)
+#include <sys/auxv.h>
+
+// NEON is architecturally mandatory on aarch64. The SVE kernels live in
+// the separately-compiled SVE TU and are callable only when that TU was
+// built (see lsmt/CMakeLists.txt for the toolchain probe).
+extern "C" uint32_t lsmt_neon_inner_search_u32(const uint32_t *base, uint32_t x);
+extern "C" uint32_t lsmt_neon_inner_search_u64(const uint64_t *base, uint64_t x);
+#if defined(OVERLAYBD_ENABLE_SVE)
+extern "C" uint32_t lsmt_sve_inner_search_u32(const uint32_t *base, uint32_t x);
+extern "C" uint32_t lsmt_sve_inner_search_u64(const uint64_t *base, uint64_t x);
+#endif
+
+namespace {
+
+// Independent scalar reference: number of keys <= x in a sorted node.
+// Written from the spec here rather than shared with production code, so a
+// bug shared between production implementations cannot hide the mismatch.
+uint32_t ref32(const uint32_t *k, uint32_t x) {
+    uint32_t m = 0;
+    for (int i = 0; i < 16; i++)
+        m |= ((k[i] <= x) << i);
+    return __builtin_popcount(m);
+}
+uint32_t ref64(const uint64_t *k, uint64_t x) {
+    uint32_t m = 0;
+    for (int i = 0; i < 8; i++)
+        m |= ((k[i] <= x) << i);
+    return __builtin_popcount(m);
+}
+
+// Fixed-seed xorshift64: any failure is reproducible.
+struct Rng {
+    uint64_t s = 0x243F6A8885A308D3ULL;
+    uint64_t next() {
+        s ^= s << 13;
+        s ^= s >> 7;
+        s ^= s << 17;
+        return s;
+    }
+};
+
+constexpr uint32_t BX32[] = {0, 1, 0x7fffffffu, 0x80000000u, 0xffffffffu};
+constexpr uint64_t BX64[] = {0, 1, 0x7fffffffffffffffUL, 0x8000000000000000UL,
+                             UINT64_MAX};
+constexpr int kTrials = 4096;
+
+bool sve_available() { return getauxval(AT_HWCAP) & (1UL << 22); }
+
+// Generates ascending nodes and mixed queries (boundary / exact-key /
+// random); returns the number of mismatches between `fn` and the reference.
+template <typename Fn>
+int mismatches_u32(Fn &&fn) {
+    Rng rng;
+    int bad = 0;
+    for (int t = 0; t < kTrials; t++) {
+        uint32_t k[16];
+        uint32_t v = (uint32_t)rng.next();
+        for (auto &kk : k) {
+            v += 1 + (uint32_t)(rng.next() % 1000);
+            kk = v;
+        }
+        uint32_t x;
+        if ((t & 15) == 0)
+            x = BX32[(t >> 4) % 5]; // boundary values
+        else if ((t & 3) == 0)
+            x = k[rng.next() & 15]; // exact-key hits
+        else
+            x = (uint32_t)rng.next(); // random
+        bad += (fn(k, x) != ref32(k, x));
+    }
+    return bad;
+}
+template <typename Fn>
+int mismatches_u64(Fn &&fn) {
+    Rng rng;
+    int bad = 0;
+    for (int t = 0; t < kTrials; t++) {
+        uint64_t k[8];
+        uint64_t v = rng.next();
+        for (auto &kk : k) {
+            v += 1 + (rng.next() % 1000);
+            kk = v;
+        }
+        uint64_t x;
+        if ((t & 15) == 0)
+            x = BX64[(t >> 4) % 5];
+        else if ((t & 3) == 0)
+            x = k[rng.next() & 7];
+        else
+            x = rng.next();
+        bad += (fn(k, x) != ref64(k, x));
+    }
+    return bad;
+}
+
+} // namespace
+
+// NEON runs on every aarch64 machine, no gating needed.
+TEST(inner_search, neon_vs_reference) {
+    EXPECT_EQ(0, mismatches_u32([](const uint32_t *k,
+                                   uint32_t x) { return lsmt_neon_inner_search_u32(k, x); }));
+    EXPECT_EQ(0, mismatches_u64([](const uint64_t *k,
+                                   uint64_t x) { return lsmt_neon_inner_search_u64(k, x); }));
+}
+
+#if defined(OVERLAYBD_ENABLE_SVE)
+// SVE kernels fault on hardware without SVE, so skip (not fail) when the
+// machine does not report HWCAP_SVE.
+TEST(inner_search, sve_vs_reference) {
+    if (!sve_available())
+        GTEST_SKIP() << "SVE not available on this machine";
+    EXPECT_EQ(0, mismatches_u32([](const uint32_t *k,
+                                   uint32_t x) { return lsmt_sve_inner_search_u32(k, x); }));
+    EXPECT_EQ(0, mismatches_u64([](const uint64_t *k,
+                                   uint64_t x) { return lsmt_sve_inner_search_u64(k, x); }));
+}
+#endif
+
+#else // !__aarch64__
+
+// Keep a visible test on non-aarch64 CI runners, where the aarch64 kernels
+// are not part of the build.
+TEST(inner_search, aarch64_only) {
+    GTEST_SKIP() << "aarch64 only";
+}
+
+#endif // __aarch64__


### PR DESCRIPTION
**What this PR does / why we need it**:

The LSMT linearized B+tree inner search has an AVX-512 accelerated path on x86_64, but on aarch64 it always fell back to the scalar loop. This PR adds SIMD acceleration for aarch64, mirroring the x86_64 design.


Measured with a single-thread microbenchmark (ns per inner_search, working sets from L1 to 256MB): the u32/16-key kernel improves ~1.9–2.7x with NEON and ~2.1–2.7x with SVE over the scalar loop; the u64/8-key kernel ~1.2–1.7x and ~1.5–1.7x respectively. The gain is stable across all working-set sizes.


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Please check the following list**:
- [x]  Does the affected code have corresponding tests, e.g. unit test, E2E test?
- [ ]  Does this change require a documentation update?
- [ ]  Does this introduce breaking changes that would require an announcement or bumping the major version?
- [x]  Do all new files have an appropriate license header?

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues directly to https://github.com/containerd/overlaybd/blob/main/MAINTAINERS. -->
