### PR TITLE
fix UB when opening an empty sparse layer

### DIFF
--- a/src/overlaybd/lsmt/file.cpp
+++ b/src/overlaybd/lsmt/file.cpp
@@ -1504,7 +1504,7 @@ IFileRW *open_file_rw(IFile *fdata, IFile *findex, bool ownership) {
         if (LSMTSparseFile::create_mappings(fdata, mappings) == -1) {
             LOG_ERROR_RETURN(0, nullptr, "failed to create segment mappings from sparse file!");
         }
-        pi = create_memory_index0((const SegmentMapping *)&mappings[0], mappings.size(),
+        pi = create_memory_index0(mappings.data(), mappings.size(),
                                   HeaderTrailer::SPACE / ALIGNMENT, stat.st_size / ALIGNMENT);
         if (!pi) {
             LOG_ERROR_RETURN(0, nullptr, "failed to create memory index from sparse file!");


### PR DESCRIPTION
**What this PR does / why we need it**:

`open_file_rw()` uses `&mappings[0]` even when `mappings` may be empty. An empty sparse file produces zero `SegmentMapping` entries from `create_mappings()`, making `&mappings[0]` undefined behavior.

Use `mappings.data()` instead, which is well-defined for an empty vector and allows the existing zero-length case to be handled safely.


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Please check the following list**:
- [ ]  Does the affected code have corresponding tests, e.g. unit test, E2E test?
- [ ]  Does this change require a documentation update?
- [ ]  Does this introduce breaking changes that would require an announcement or bumping the major version?
- [ ]  Do all new files have an appropriate license header?

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues directly to https://github.com/containerd/overlaybd/blob/main/MAINTAINERS. -->
